### PR TITLE
ci: add redis to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,8 @@
 {
-  "build": {
-    "cacheFrom": "ghcr.io/thijsfranck/courageous-comets-devcontainer",
-    "dockerfile": "Dockerfile"
-  },
   "containerEnv": {
     "POETRY_VIRTUALENVS_CREATE": "false",
+    "REDIS_HOST": "localhost",
+    "REDIS_PORT": "6379",
     "SOPS_AGE_KEY_FILE": "${containerWorkspaceFolder}/secrets/keys.txt"
   },
   "customizations": {
@@ -37,6 +35,7 @@
       }
     }
   },
+  "dockerComposeFile": "docker-compose.yaml",
   "features": {
     "ghcr.io/devcontainers-contrib/features/act:1": {},
     "ghcr.io/devcontainers-contrib/features/apt-packages": {
@@ -51,15 +50,27 @@
     }
   },
   "forwardPorts": [
-    8000
+    6379,
+    8000,
+    8001
   ],
   "name": "Courageous Comets \u2604\ufe0f",
   "portsAttributes": {
+    "6379": {
+      "label": "Redis",
+      "onAutoForward": "silent"
+    },
     "8000": {
       "label": "MkDocs",
       "onAutoForward": "notify"
+    },
+    "8001": {
+      "label": "RedisInsight",
+      "onAutoForward": "silent"
     }
   },
   "postCreateCommand": "bash .devcontainer/postcreate.sh",
-  "updateContentCommand": "bash .devcontainer/updatecontent.sh"
+  "service": "dev",
+  "updateContentCommand": "bash .devcontainer/updatecontent.sh",
+  "workspaceFolder": "/workspace"
 }

--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+
+  # This is the development container
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - ghcr.io/thijsfranck/courageous-comets-devcontainer
+    volumes:
+      - ..:/workspace
+    command: 'sleep infinity'
+
+  redis-stack:
+    image: redis/redis-stack:7.2.0-v11
+    environment:
+      REDIS_PASSWORD: redis
+    volumes:
+      - redis-stack-data:/data
+    network_mode: service:dev
+    restart: unless-stopped
+
+volumes:
+  redis-stack-data:


### PR DESCRIPTION
Set up Redis in the devcontainer.

Closes #6 

## Changes

- The devcontainer is now based on docker compose
- Redis is now available at `localhost:6379`
- RedisInsight is now available at `localhost:8001`