### PR TITLE
ci: set up docker build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,16 +30,16 @@ jobs:
           python-version: 3.12
           poetry-version: 1.8.3
 
-#      - name: Build the Application
-#        run: poetry build -f wheel
-#        shell: bash
-#
-#      - name: Build and Publish the Docker Image
-#        uses: docker/build-push-action@v6
-#        with:
-#          context: .
-#          push: true
-#          tags: ghcr.io/thijsfranck/courageous-comets:${{ github.ref_name }},ghcr.io/thijsfranck/courageous-comets:latest
+      - name: Build the Application
+        run: poetry build -f wheel
+        shell: bash
+
+      - name: Build and Publish the Docker Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/thijsfranck/courageous-comets:${{ github.ref_name }},ghcr.io/thijsfranck/courageous-comets:latest
 
       - name: Set up Git user
         uses: fregante/setup-git-user@v2.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official Python 3.12 slim image as the base image
+FROM python:3.12-slim
+
+# Add a non-root user
+RUN adduser --system courageous-comets
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the wheel file to the working directory
+COPY dist/*.whl ./
+
+# Install the wheel file and clean up to reduce image size
+RUN pip install --no-cache-dir *.whl && \
+    rm *.whl
+
+# Switch to the non-root user
+USER courageous-comets
+
+# Run the application
+ENTRYPOINT ["python", "-m", "courageous_comets"]

--- a/courageous_comets/__main__.py
+++ b/courageous_comets/__main__.py
@@ -1,0 +1,1 @@
+# Placeholder - run the main program here


### PR DESCRIPTION
Publish a new version of the docker image whenever a tag is pushed to the repository.

Closes #8 

## Changes
- Add a Dockerfile for the Python app. Note: run `poetry build` before building the image.
- Enable the Docker section of the publish action.
- Add a placeholder `__main__.py` file at the root of the application package. 