### PR TITLE
feat: download nltk resources on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,6 @@ pyrightconfig.json
 
 # Vim
 *.vim
+
+# NLTK
+nltk_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN adduser --system courageous-comets
 # Set the working directory
 WORKDIR /app
 
+# Assign the working directory to the non-root user and set the permissions
+RUN chown -R courageous-comets /app && \
+    chmod -R 0600 /app
+
 # Copy the app config and the wheel file to the working directory and set the permissions
 COPY --chown=courageous-comets --chmod=0400 application.yaml dist/*.whl ./
 

--- a/application.yaml
+++ b/application.yaml
@@ -1,3 +1,6 @@
 cogs:
   - courageous_comets.cogs.ping
   - jishaku
+nltk:
+  - stopwords
+  - vader_lexicon

--- a/courageous_comets/exceptions.py
+++ b/courageous_comets/exceptions.py
@@ -34,3 +34,7 @@ class ConfigurationValueError[T](CourageousCometsError):
 
 class DatabaseConnectionError(CourageousCometsError):
     """Raised when a connection to the database cannot be established."""
+
+
+class NltkInitializationError(CourageousCometsError):
+    """Raised when the application fails to download the NLTK dependencies on startup."""

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -107,6 +107,7 @@ setup_logging(level=LOG_LEVEL)
 try:
     DISCORD_TOKEN = read_discord_token()
     BOT_CONFIG_PATH = read_bot_config_path()
+    NLTK_DATA_DIR = os.getenv("NLTK_DATA_DIR", "nltk_data")
     REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
     REDIS_PORT = read_redis_port()
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -7,6 +7,7 @@ The following environment variables are available to configure the application:
 | [`DISCORD_TOKEN`](#discord_token)     | The Discord bot token.                    | Yes      | -                  |
 | [`BOT_CONFIG_PATH`](#bot_config_path) | The path to the bot's configuration file. | No       | `application.yaml` |
 | [`LOG_LEVEL`](#log_level)             | The minimum log level.                    | No       | `INFO`             |
+| [`NLTK_DATA_DIR`](#nltk_data_dir)     | The directory containing NLTK data files. | No       | `/nltk_data`       |
 | [`REDIS_HOST`](#redis_host)           | The Redis host.                           | No       | `localhost`        |
 | [`REDIS_PORT`](#redis_port)           | The Redis port.                           | No       | `6379`             |
 | [`REDIS_PASSWORD`](#redis_password)   | The Redis password.                       | No       | -                  |
@@ -54,6 +55,11 @@ The minimum log level to display. The following levels are available:
 - `CRITICAL`
 
 The default log level is `INFO`.
+
+### `NLTK_DATA_DIR`
+
+The directory containing NLTK data files. By default, this is set to `nltk_data` in the directory from which the
+application is launched. In the Docker image, this directory is located at `/app/nltk_data`.
 
 ### `REDIS_HOST`
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -746,6 +746,17 @@ test = ["coverage (>=6.3.2)", "flake8 (>=4.0.1)", "isort (>=5.10.1)", "pylint (>
 voice = ["yt-dlp (>=2022.3.8)"]
 
 [[package]]
+name = "joblib"
+version = "1.4.2"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "joblib-1.4.2-py3-none-any.whl", hash = "sha256:06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6"},
+    {file = "joblib-1.4.2.tar.gz", hash = "sha256:2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e"},
+]
+
+[[package]]
 name = "markdown"
 version = "3.6"
 description = "Python implementation of John Gruber's Markdown."
@@ -1049,6 +1060,31 @@ files = [
     {file = "multidict-6.0.5-py3-none-any.whl", hash = "sha256:0d63c74e3d7ab26de115c49bffc92cc77ed23395303d496eae515d4204a625e7"},
     {file = "multidict-6.0.5.tar.gz", hash = "sha256:f7e301075edaf50500f0b341543c41194d8df3ae5caf4702f2095f3ca73dd8da"},
 ]
+
+[[package]]
+name = "nltk"
+version = "3.8.1"
+description = "Natural Language Toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "nltk-3.8.1-py3-none-any.whl", hash = "sha256:fd5c9109f976fa86bcadba8f91e47f5e9293bd034474752e92a520f81c93dda5"},
+    {file = "nltk-3.8.1.zip", hash = "sha256:1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3"},
+]
+
+[package.dependencies]
+click = "*"
+joblib = "*"
+regex = ">=2021.8.3"
+tqdm = "*"
+
+[package.extras]
+all = ["matplotlib", "numpy", "pyparsing", "python-crfsuite", "requests", "scikit-learn", "scipy", "twython"]
+corenlp = ["requests"]
+machine-learning = ["numpy", "python-crfsuite", "scikit-learn", "scipy"]
+plot = ["matplotlib"]
+tgrep = ["pyparsing"]
+twitter = ["twython"]
 
 [[package]]
 name = "nodeenv"
@@ -1583,6 +1619,26 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.66.4"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
+    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1823,4 +1879,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "e98a0974533a45bded47b6f6d1f0da774778f2b01134525a10ed46418e46f620"
+content-hash = "41c4396e0eb0c4b6c7faa1024f39cea166058996cca3e4a043c1e703ef6bc01c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ jishaku = "^2.5.2"
 python-dotenv = "^1.0.1"
 pyyaml = "^6.0.1"
 redis = { extras = ["hiredis"], version = "^5.0.7" }
+nltk = "^3.8.1"
 
 [tool.poetry.dev-dependencies]
 commitizen = "3.27.0"


### PR DESCRIPTION
Add NLTK as a project dependency, add startup routine that downloads all NLTK resources specified in the configuration file.

## Changes

- Add NLTK to the project dependencies
- Add `init_nltk` and `download_nltk_resource` functions that are called from the `main` function on startup.
- Add configuration option `NLTK_DATA_DIR` that can be used to specify where NLTK resources should be stored.
- Extend Dockerfile to allow the NLTK resources to be stored in the `/app` folder.
- Update the documentation with the new configuration option.