### PR TITLE
feat: add sentiment analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets/.venv/share/nltk_data
+      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets/nltk_data
+      NLTK_DATA: ${{ github.workspace }}/nltk_data
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,10 @@ jobs:
           version: 1.1.370
           python-version: 3.12
 
+      - name: Download NLTK data
+        run: poetry run python -m nltk.downloader stopwords vader_lexicon
+        shell: bash
+
       - name: Run tests
         run: poetry run pytest
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
+      NLTK_DATA_DIR: /home/runner/nltk_data
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-      NLTK_DATA_DIR: /home/runner/nltk_data
+      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets/.venv/share/nltk_data
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
-      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets
+      NLTK_DATA_DIR: /home/runner/work/courageous-comets/courageous-comets/nltk_data
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,6 @@ jobs:
           version: 1.1.370
           python-version: 3.12
 
-      - name: Download NLTK data
-        run: poetry run python -m nltk.downloader stopwords vader_lexicon
-        shell: bash
-
       - name: Run tests
         run: poetry run pytest
         shell: bash

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -19,4 +20,8 @@ def _load_nltk_data(application_config: dict) -> None:
     resources = application_config.get("nltk", [])
 
     for resource in resources:
-        nltk.download(resource, quiet=True)
+        nltk.download(
+            resource,
+            quiet=True,
+            download_dir=os.getenv("NLTK_DATA_DIR", "nltk_data"),
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -22,6 +22,5 @@ def _load_nltk_data(application_config: dict) -> None:
     for resource in resources:
         nltk.download(
             resource,
-            quiet=True,
             download_dir=os.getenv("NLTK_DATA_DIR", "nltk_data"),
         )

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture(scope="session")
+def application_config() -> dict:
+    """Load the application configuration for testing."""
+    with Path("application.yaml").open("r") as file:
+        return yaml.safe_load(file)
+
+
+@pytest.fixture(scope="session")
+def _load_nltk_data(application_config: dict) -> None:
+    """Load the NLTK data for testing."""
+    import nltk
+
+    resources = application_config.get("nltk", [])
+
+    for resource in resources:
+        nltk.download(resource, quiet=True)

--- a/conftest.py
+++ b/conftest.py
@@ -21,5 +21,6 @@ def _load_nltk_data(application_config: dict) -> None:
     for resource in resources:
         nltk.download(
             resource,
-            download_dir=os.getenv("NLTK_DATA_DIR", "nltk_data"),
+            quiet=True,
+            download_dir=os.getenv("NLTK_DATA", "nltk_data"),
         )

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import nltk
 import pytest
 import yaml
 
@@ -15,8 +16,6 @@ def application_config() -> dict:
 @pytest.fixture(scope="session", autouse=True)
 def _load_nltk_data(application_config: dict) -> None:
     """Load the NLTK data for testing."""
-    import nltk
-
     resources = application_config.get("nltk", [])
 
     for resource in resources:

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ def application_config() -> dict:
         return yaml.safe_load(file)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def _load_nltk_data(application_config: dict) -> None:
     """Load the NLTK data for testing."""
     import nltk

--- a/courageous_comets/redis/keys.py
+++ b/courageous_comets/redis/keys.py
@@ -42,5 +42,20 @@ class KeySchema:
         """
         return f"{guild_id}:messages:tokens"
 
+    @prefix_key
+    def sentiment_tokens(
+        self,
+        guild_id: int,
+        channel_id: int,
+        user_id: int,
+        message_id: int,
+    ) -> str:
+        """
+        Key to sentiment tokens for a message.
+
+        Redis type: hash
+        """
+        return f"{guild_id}:{channel_id}:{user_id}:{message_id}:sentiment"
+
 
 key_schema = KeySchema()

--- a/courageous_comets/sentiment.py
+++ b/courageous_comets/sentiment.py
@@ -10,7 +10,6 @@ from courageous_comets.redis.keys import key_schema
 MAX_MESSAGE_LENGTH = 256
 
 logger = logging.getLogger(__name__)
-sia = SentimentIntensityAnalyzer()
 
 
 class SentimentResult(TypedDict):
@@ -46,6 +45,7 @@ def calculate_sentiment(content: str, key: str) -> SentimentResult:
     if truncated != content:
         logger.warning("Truncated message %s to %s characters", key, MAX_MESSAGE_LENGTH)
 
+    sia = SentimentIntensityAnalyzer()
     result = sia.polarity_scores(truncated)
 
     return cast(SentimentResult, result)

--- a/courageous_comets/sentiment.py
+++ b/courageous_comets/sentiment.py
@@ -96,7 +96,7 @@ async def store_sentiment(message: Message, redis: Redis) -> None:
     sentiment = calculate_sentiment(message.content, key)
 
     # Store the sentiment in Redis
-    await redis.hmset(key, sentiment)  # type: ignore
+    await redis.hset(key, mapping=sentiment)  # type: ignore
 
     logger.info("Stored sentiment for message %s", key)
 

--- a/courageous_comets/sentiment.py
+++ b/courageous_comets/sentiment.py
@@ -1,0 +1,127 @@
+import logging
+from typing import TypedDict, cast
+
+from discord import Message
+from nltk.sentiment import SentimentIntensityAnalyzer
+from redis.asyncio import Redis
+
+from courageous_comets.redis.keys import key_schema
+
+MAX_MESSAGE_LENGTH = 256
+
+logger = logging.getLogger(__name__)
+sia = SentimentIntensityAnalyzer()
+
+
+class SentimentResult(TypedDict):
+    """Result of sentiment analysis."""
+
+    neg: float
+    neu: float
+    pos: float
+    compound: float
+
+
+def calculate_sentiment(content: str, key: str) -> SentimentResult:
+    """
+    Calculate the sentiment of a message.
+
+    Uses the NLTK sentiment intensity analyzer to calculate the sentiment of a message.
+
+    Messages can be up to 256 characters long. If a message is longer than 256 characters,
+    it will be truncated.
+
+    Parameters
+    ----------
+    content : str
+        The message content to analyze.
+
+    Returns
+    -------
+    SentimentResult
+        The sentiment of the message.
+    """
+    truncated = content[:MAX_MESSAGE_LENGTH]
+
+    if truncated != content:
+        logger.warning("Truncated message %s to %s characters", key, MAX_MESSAGE_LENGTH)
+
+    result = sia.polarity_scores(truncated)
+
+    return cast(SentimentResult, result)
+
+
+async def store_sentiment(message: Message, redis: Redis) -> None:
+    """
+    Calculate the sentiment of a message and store the result in Redis.
+
+    A message must have a guild, channel, author and message ID. If any of these are missing,
+    the message will be ignored.
+
+    Empty messages will also be ignored.
+
+    Parameters
+    ----------
+    message : discord.Message
+        The message to process.
+
+    Returns
+    -------
+    SentimentResult
+        The sentiment of the message.
+    """
+    # Ignore empty messages
+    if not message.content:
+        return
+
+    # Extract the IDs from the message
+    guild_id = message.guild.id if message.guild else 0
+    channel_id = message.channel.id if message.channel else 0
+    user_id = message.author.id if message.author else 0
+    message_id = message.id if message.id else 0
+
+    # Ignore messages without all required IDs
+    if not all((guild_id, channel_id, user_id, message_id)):
+        return
+
+    # Construct the Redis key
+    key = key_schema.sentiment_tokens(
+        guild_id=guild_id,
+        channel_id=channel_id,
+        user_id=user_id,
+        message_id=message_id,
+    )
+
+    # Calculate the sentiment
+    sentiment = calculate_sentiment(message.content, key)
+
+    # Store the sentiment in Redis
+    await redis.hmset(key, sentiment)  # type: ignore
+
+    logger.info("Stored sentiment for message %s", key)
+
+
+async def get_sentiment(key: str, redis: Redis) -> SentimentResult:
+    """
+    Retrieve the sentiment of a message from Redis.
+
+    Parameters
+    ----------
+    key : str
+        The Redis key to retrieve the sentiment from.
+    redis : redis.asyncio.Redis
+        The Redis connection instance.
+
+    Returns
+    -------
+    SentimentResult
+        The sentiment of the message.
+    """
+    neg, neu, pos, compound = await redis.hmget(key, "neg", "neu", "pos", "compound")  # type: ignore
+
+    return {
+        "neg": float(neg or 0),
+        "neu": float(neu or 0),
+        "pos": float(pos or 0),
+        "compound": float(compound or 0),
+    }

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -110,7 +110,7 @@ setup_logging(level=LOG_LEVEL)
 try:
     DISCORD_TOKEN = read_discord_token()
     BOT_CONFIG_PATH = read_bot_config_path()
-    NLTK_DATA_DIR = os.getenv("NLTK_DATA_DIR", "nltk_data")
+    NLTK_DATA_DIR = os.getenv("NLTK_DATA", "nltk_data")
     REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
     REDIS_PORT = read_redis_port()
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")

--- a/courageous_comets/test__sentiment.py
+++ b/courageous_comets/test__sentiment.py
@@ -1,0 +1,183 @@
+from unittest.mock import Mock
+
+import pytest
+from pytest_mock import MockerFixture, MockType
+from redis.asyncio import Redis
+
+from .sentiment import (
+    MAX_MESSAGE_LENGTH,
+    calculate_sentiment,
+    get_sentiment,
+    logger,
+    store_sentiment,
+)
+
+
+@pytest.fixture()
+def redis(mocker: MockerFixture) -> MockerFixture:
+    """Create a mock Redis instance for testing."""
+    mock = mocker.AsyncMock(spec=Redis)
+    mock.hmset = mocker.AsyncMock()
+    mock.hmget = mocker.AsyncMock()
+    return mock
+
+
+def test__calculate_sentiment_analyzes_sentiment_of_given_text(
+    *,
+    mocker: MockerFixture,
+) -> None:
+    """
+    Test whether the sentiment calculation analyzes the sentiment of the given text.
+
+    Asserts
+    -------
+    - The function produces sentiment scores for the given text.
+    """
+    result = calculate_sentiment("I love this product!", "test")
+
+    assert result == {
+        "neg": mocker.ANY,
+        "neu": mocker.ANY,
+        "pos": mocker.ANY,
+        "compound": mocker.ANY,
+    }
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        ("a" * MAX_MESSAGE_LENGTH, False),
+        ("a" * (MAX_MESSAGE_LENGTH + 1), True),
+    ],
+)
+def test__calculate_sentiment_truncates_long_messages(
+    *,
+    mocker: MockerFixture,
+    message: str,
+    expected: bool,
+) -> None:
+    """
+    Test whether the sentiment calculation truncates long messages.
+
+    Asserts
+    -------
+    - The function truncates messages longer than 256 characters.
+    """
+    logger_warning = mocker.spy(logger, "warning")
+    calculate_sentiment(message, "test")
+    assert logger_warning.called == expected
+
+
+@pytest.mark.asyncio()
+async def test__store_sentiment_calculates_and_stores_sentiment(
+    *,
+    mocker: MockerFixture,
+    redis: MockType,
+) -> None:
+    """
+    Test whether the store sentiment function calculates and stores the sentiment of a message.
+
+    Asserts
+    -------
+    - The sentiment is calculated for the message content.
+    - The sentiment is stored in the database.
+    """
+    message = mocker.Mock(
+        content="I love this product!",
+        guild=Mock(id=1),
+        channel=Mock(id=1),
+        author=Mock(id=1),
+        id=1,
+    )
+
+    await store_sentiment(message, redis)
+
+    redis.hmset.assert_awaited_with(
+        "courageous_comets:1:1:1:1:sentiment",
+        {"neg": mocker.ANY, "neu": mocker.ANY, "pos": mocker.ANY, "compound": mocker.ANY},
+    )
+
+
+@pytest.mark.asyncio()
+async def test__store_sentiment_ignores_empty_messages(
+    *,
+    mocker: MockerFixture,
+    redis: MockType,
+) -> None:
+    """
+    Test whether the store sentiment function ignores empty messages.
+
+    Asserts
+    -------
+    - The database is not updated when the message is empty.
+    """
+    message = mocker.Mock(content="")
+    await store_sentiment(message, redis)
+    redis.hmset.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        Mock(content="test", guild=None, channel=None, author=None, id=1),
+        Mock(content="test", guild=Mock(id=1), channel=None, author=None, id=1),
+        Mock(content="test", guild=Mock(id=1), channel=Mock(id=1), author=None, id=1),
+    ],
+)
+@pytest.mark.asyncio()
+async def test__store_sentiment_ignores_messages_without_ids(
+    *,
+    redis: MockType,
+    message: MockType,
+) -> None:
+    """
+    Test whether the store sentiment function ignores messages without IDs.
+
+    Asserts
+    -------
+    - The database is not updated when the message is missing IDs.
+    """
+    await store_sentiment(message, redis)
+    redis.hmset.assert_not_awaited()
+
+
+@pytest.mark.asyncio()
+async def test__get_sentiment_retrieves_sentiment_from_redis(
+    *,
+    redis: MockType,
+) -> None:
+    """
+    Test whether the get sentiment function retrieves the sentiment of a message from Redis.
+
+    Asserts
+    -------
+    - The sentiment is retrieved from the database.
+    """
+    key = "courageous_comets:1:1:1:1:sentiment"
+    redis.hmget.return_value = ["1.0", "1.0", "1.0", "1.0"]
+
+    result = await get_sentiment(key, redis)
+
+    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
+    assert result == {"neg": 1.0, "neu": 1.0, "pos": 1.0, "compound": 1.0}
+
+
+@pytest.mark.asyncio()
+async def test__get_sentiment_handles_missing_sentiment(
+    *,
+    redis: MockType,
+) -> None:
+    """
+    Test whether the get sentiment function handles missing sentiment in Redis.
+
+    Asserts
+    -------
+    - The function returns default sentiment values when the sentiment is missing.
+    """
+    key = "courageous_comets:1:1:1:1:sentiment"
+    redis.hmget.return_value = [None, None, None, None]
+
+    result = await get_sentiment(key, redis)
+
+    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
+    assert result == {"neg": 0.0, "neu": 0.0, "pos": 0.0, "compound": 0.0}

--- a/courageous_comets/test__sentiment.py
+++ b/courageous_comets/test__sentiment.py
@@ -17,7 +17,7 @@ from .sentiment import (
 def redis(mocker: MockerFixture) -> MockerFixture:
     """Create a mock Redis instance for testing."""
     mock = mocker.AsyncMock(spec=Redis)
-    mock.hmset = mocker.AsyncMock()
+    mock.hset = mocker.AsyncMock()
     mock.hmget = mocker.AsyncMock()
     return mock
 
@@ -92,9 +92,14 @@ async def test__store_sentiment_calculates_and_stores_sentiment(
 
     await store_sentiment(message, redis)
 
-    redis.hmset.assert_awaited_with(
+    redis.hset.assert_awaited_with(
         "courageous_comets:1:1:1:1:sentiment",
-        {"neg": mocker.ANY, "neu": mocker.ANY, "pos": mocker.ANY, "compound": mocker.ANY},
+        mapping={
+            "neg": mocker.ANY,
+            "neu": mocker.ANY,
+            "pos": mocker.ANY,
+            "compound": mocker.ANY,
+        },
     )
 
 
@@ -113,7 +118,7 @@ async def test__store_sentiment_ignores_empty_messages(
     """
     message = mocker.Mock(content="")
     await store_sentiment(message, redis)
-    redis.hmset.assert_not_awaited()
+    redis.hset.assert_not_awaited()
 
 
 @pytest.mark.parametrize(
@@ -138,7 +143,7 @@ async def test__store_sentiment_ignores_messages_without_ids(
     - The database is not updated when the message is missing IDs.
     """
     await store_sentiment(message, redis)
-    redis.hmset.assert_not_awaited()
+    redis.hset.assert_not_awaited()
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
Adds a new module for calculating the sentiment of a Discord message.

Closes #21 

## Changes

- Added the `courageous-comets.sentiment` module with functions for calculating sentiment, as well as storing and retrieving the results
- Added unit tests for the sentiment analysis
- Extended the key schema with a keyer for the sentiment
- Set up `conftest.py` to load NLTK resources (especially important during CI)