### PR TITLE
fix: handle contractions in tokenizer

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -2,5 +2,6 @@ cogs:
   - courageous_comets.cogs.ping
   - jishaku
 nltk:
+  - punkt
   - stopwords
   - vader_lexicon

--- a/courageous_comets/test__words.py
+++ b/courageous_comets/test__words.py
@@ -1,0 +1,93 @@
+import pytest
+
+from courageous_comets.words import tokenize_sentence, word_frequency
+
+
+@pytest.mark.parametrize(
+    ("sentence", "expected"),
+    [
+        (
+            "The quick brown fox jumps over the lazy dog",
+            ["quick", "brown", "fox", "jump", "lazi", "dog"],
+        ),
+        (
+            "Hello, world!",
+            ["hello", "world"],
+        ),
+        (
+            "I'm sorry, Dave. I'm afraid I can't do that.",
+            ["sorri", "dave", "afraid"],
+        ),
+        (
+            "I've been waiting for you, Obi-Wan. We meet again at last.",
+            ["wait", "obi-wan", "meet", "last"],
+        ),
+        (
+            "I don't like sand. It's coarse and rough and irritating and it gets everywhere.",
+            ["like", "sand", "coars", "rough", "irrit", "get", "everywher"],
+        ),
+        (
+            "You were the chosen one! It was said that you would destroy the Sith, not join them.",
+            ["chosen", "one", "said", "would", "destroy", "sith", "join"],
+        ),
+        (
+            "Bring balance to the Force, not leave it in darkness.",
+            ["bring", "balanc", "forc", "leav", "dark"],
+        ),
+        (
+            "I'm gonna wreck it!",
+            ["go", "wreck"],
+        ),
+        (
+            "I'm gonna wreck it! I'm gonna wreck it!",
+            ["go", "wreck", "go", "wreck"],
+        ),
+        (
+            "",  # Empty string
+            [],
+        ),
+    ],
+)
+def test__tokenize_sentence(sentence: str, expected: list[str]) -> None:
+    """
+    Test whether a sentence is tokenized correctly.
+
+    Asserts
+    -------
+    - Contractions are expanded.
+    - The sentence is split into words.
+    - Punctuation is removed.
+    - The words are stemmed.
+    - Stopwords and words with a length of 1 are removed.
+    """
+    result = tokenize_sentence(sentence)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("words", "expected"),
+    [
+        (
+            ["go", "wreck"],
+            {"go": 1, "wreck": 1},
+        ),
+        (
+            ["go", "wreck", "go", "wreck"],
+            {"go": 2, "wreck": 2},
+        ),
+        (
+            [],
+            {},
+        ),
+    ],
+)
+def test__word_frequency(words: list[str], expected: dict[str, int]) -> None:
+    """
+    Test whether the frequency of words is calculated correctly.
+
+    Asserts
+    -------
+    - The frequency of each word is counted.
+    """
+    result = word_frequency(words)
+    assert result == expected

--- a/courageous_comets/words.py
+++ b/courageous_comets/words.py
@@ -4,8 +4,6 @@ import contractions
 from nltk.stem.snowball import SnowballStemmer, stopwords
 from nltk.tokenize import word_tokenize
 
-STOP_WORDS = set(stopwords.words("english"))
-
 
 def tokenize_sentence(sentence: str) -> list[str]:
     """
@@ -43,7 +41,9 @@ def tokenize_sentence(sentence: str) -> list[str]:
     stemmed_words = [stemmer.stem(word) for word in words]
 
     # Remove stopwords and words with a length of 1
-    return [word for word in stemmed_words if len(word) > 1 and word not in STOP_WORDS]
+    stop_words = set(stopwords.words("english"))
+
+    return [word for word in stemmed_words if len(word) > 1 and word not in stop_words]
 
 
 def word_frequency(words: list[str]) -> dict[str, int]:

--- a/courageous_comets/words.py
+++ b/courageous_comets/words.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
+from collections import Counter
 
+import contractions
 from nltk.stem.snowball import SnowballStemmer, stopwords
 from nltk.tokenize import word_tokenize
 
@@ -7,19 +8,56 @@ STOP_WORDS = set(stopwords.words("english"))
 
 
 def tokenize_sentence(sentence: str) -> list[str]:
-    """Split a sentence into tokens.
-
-    The tokenizer applies stemming to the words that make up the sentence
-    using the Snowball stemmer and removes stopwords.
     """
+    Split a sentence into tokens.
+
+    The tokenizer applies the following steps:
+
+    - Expand contractions.
+    - Break the sentence into words.
+    - Stem the words.
+    - Remove stopwords and words with a length of 1.
+
+    Parameters
+    ----------
+    sentence : str
+        The sentence to tokenize.
+
+    Returns
+    -------
+    list[str]
+        The tokens derived from the sentence.
+
+    Notes
+    -----
+    The tokenizer is intended to be used with English text.
+    """
+    # Expand contractions
+    expanded = contractions.fix(sentence)
+
+    # Break the sentence into words
+    words = word_tokenize(expanded)
+
+    # Stem the words
     stemmer = SnowballStemmer("english")
-    stemmed_words = [stemmer.stem(token) for token in word_tokenize(sentence)]
+    stemmed_words = [stemmer.stem(word) for word in words]
+
+    # Remove stopwords and words with a length of 1
     return [word for word in stemmed_words if len(word) > 1 and word not in STOP_WORDS]
 
 
 def word_frequency(words: list[str]) -> dict[str, int]:
-    """Count the number of times each word appears in words."""
-    frequency: dict[str, int] = defaultdict(int)
-    for word in words:
-        frequency[word] += 1
-    return frequency
+    """
+    Count the number of times each word appears in the given list of words.
+
+    Parameters
+    ----------
+    words : list[str]
+        The list of words to count the frequency of.
+
+    Returns
+    -------
+    dict[str, int]
+        The frequency of each word in words.
+    """
+    return Counter(words)

--- a/poetry.lock
+++ b/poetry.lock
@@ -121,6 +121,17 @@ files = [
 ]
 
 [[package]]
+name = "anyascii"
+version = "0.3.2"
+description = "Unicode to ASCII transliteration"
+optional = false
+python-versions = ">=3.3"
+files = [
+    {file = "anyascii-0.3.2-py3-none-any.whl", hash = "sha256:3b3beef6fc43d9036d3b0529050b0c48bfad8bc960e9e562d7223cfb94fe45d4"},
+    {file = "anyascii-0.3.2.tar.gz", hash = "sha256:9d5d32ef844fe225b8bc7cba7f950534fae4da27a9bf3a6bea2cb0ea46ce4730"},
+]
+
+[[package]]
 name = "argcomplete"
 version = "3.3.0"
 description = "Bash tab completion for argparse"
@@ -379,6 +390,19 @@ pyyaml = ">=3.08"
 questionary = ">=2.0,<3.0"
 termcolor = ">=1.1,<3"
 tomlkit = ">=0.5.3,<1.0.0"
+
+[[package]]
+name = "contractions"
+version = "0.1.73"
+description = "Fixes contractions such as `you're` to you `are`"
+optional = false
+python-versions = "*"
+files = [
+    {file = "contractions-0.1.73-py2.py3-none-any.whl", hash = "sha256:398cee3b69c37307a50dce4930d961a0f42b48fdae9562df73bed5683008d3bc"},
+]
+
+[package.dependencies]
+textsearch = ">=0.0.21"
 
 [[package]]
 name = "decli"
@@ -1289,6 +1313,44 @@ files = [
 wcwidth = "*"
 
 [[package]]
+name = "pyahocorasick"
+version = "2.1.0"
+description = "pyahocorasick is a fast and memory efficient library for exact or approximate multi-pattern string search.  With the ``ahocorasick.Automaton`` class, you can find multiple key string occurrences at once in some input text.  You can use it as a plain dict-like Trie or convert a Trie to an automaton for efficient Aho-Corasick search. And pickle to disk for easy reuse of large automatons. Implemented in C and tested on Python 3.6+. Works on Linux, macOS and Windows. BSD-3-Cause license."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyahocorasick-2.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8c46288044c4f71392efb4f5da0cb8abd160787a8b027afc85079e9c3d7551eb"},
+    {file = "pyahocorasick-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1f15529c83b8c6e0548d7d3c5631fefa23fba5190e67be49d6c9e24a6358ff9c"},
+    {file = "pyahocorasick-2.1.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:581e3d85043f1797543796f021e8d7d48c18e594529b72d86f70ea78abc88fff"},
+    {file = "pyahocorasick-2.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c860ad9cb59e56c31aed8a5d1ee9d83a0151277b09198d027ffce213697716ed"},
+    {file = "pyahocorasick-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:4f8eba88fce34a1d8020638a4a8732c6241a5d85fe12be8669b7495d99d36b6a"},
+    {file = "pyahocorasick-2.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6e0da0a8fc78c694778dced537c1bfb8b2f178ec92a82d81539d2e35a15cba0"},
+    {file = "pyahocorasick-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:658d55e51c7588a5dba57de674241a16a3c94bf57f3bfd70022c4d7defe2b0f4"},
+    {file = "pyahocorasick-2.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9f2728ac77bab807ba65c6ef41be30358ef0c9bb6960c9fe070d43f7024cb91"},
+    {file = "pyahocorasick-2.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a58c44c407a45155dc7a3253274b5fd78ab00b579bd5685059610867cdb37142"},
+    {file = "pyahocorasick-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:d8254d6333df5eb400ed3ec8b24da9e3f5da8e28b94a71392391703a7aac568d"},
+    {file = "pyahocorasick-2.1.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:82b0d20e82cc282fd29324e8df93809cebbffb345055214ce4b7873698df02c8"},
+    {file = "pyahocorasick-2.1.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6dedb9fed92705b742d6aa3d87abb1ec999f57310ef32b962f65f4e42182fe0a"},
+    {file = "pyahocorasick-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f209796e7d354734781dd883c333596e482c70136fa76a4cb169f383e6c40bca"},
+    {file = "pyahocorasick-2.1.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8337af64c649223cff548c7204dda823e83622d63e5449bc51ae069efb2f240f"},
+    {file = "pyahocorasick-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:5ebe0d1e15afb782477e3d0aa1dce28ab9dad1200211fb785b9c1cc1208e6f04"},
+    {file = "pyahocorasick-2.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:7454ba5fa528958ca9a1bc3143f8e980bd7817ea481f46495e6ffa89675ab93b"},
+    {file = "pyahocorasick-2.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3795ac922d21fbfea40a6b3a330762e8b38ce8ba511b1eb15bf9eeb9303b2662"},
+    {file = "pyahocorasick-2.1.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8e92150849a3c13da37e37ca6374fa55960fd5c845029eca02d9b5846b26fe48"},
+    {file = "pyahocorasick-2.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:23b183600e2087f16f6c5e6185d61525ad74335f2a5b693dd6d66bba2f6a4b05"},
+    {file = "pyahocorasick-2.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:7034b26e145518610651339b8701568a3533a3114b00cf55f22bca80bff58e6d"},
+    {file = "pyahocorasick-2.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:36491675a13fe4181a6b3bccfc9032a1a5d03bd3b0a151c06f8865c16ba44b42"},
+    {file = "pyahocorasick-2.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:895ab1ff5384ee5325c74cbacafc419e534f1f110b9fb3c544cc56832ecce082"},
+    {file = "pyahocorasick-2.1.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:bf4a4b19ac37e9a7087646b8bcc306acd7a91649355d59b866b756068e35d018"},
+    {file = "pyahocorasick-2.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f44f96496aa773fc5bf302ddf968dd6b920fab34522f944392af8bde13cbe805"},
+    {file = "pyahocorasick-2.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:05b7c2ef52da247efec6fb5a011113b7e943e961e22aaaf757cb9c15083440c9"},
+    {file = "pyahocorasick-2.1.0.tar.gz", hash = "sha256:4df4845c1149e9fa4aa33f0f0aa35f5a42957a43a3d6e447c9b44e679e2672ea"},
+]
+
+[package.extras]
+testing = ["pytest", "setuptools", "twine", "wheel"]
+
+[[package]]
 name = "pydantic"
 version = "2.8.2"
 description = "Data validation using Python type hints"
@@ -1579,6 +1641,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1586,8 +1649,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1604,6 +1675,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1611,6 +1683,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1878,6 +1951,21 @@ files = [
 
 [package.extras]
 tests = ["pytest", "pytest-cov"]
+
+[[package]]
+name = "textsearch"
+version = "0.0.24"
+description = "Find strings/words in text; convenience and C speed"
+optional = false
+python-versions = "*"
+files = [
+    {file = "textsearch-0.0.24-py2.py3-none-any.whl", hash = "sha256:1bbc4cc36300fbf0bbaa865500f84e907c85f6a48faf37da6e098407b405ed09"},
+    {file = "textsearch-0.0.24.tar.gz", hash = "sha256:2d23b5c3116715b65bccc18bc870ecc236ec8480d48cd5f257cc60bf66bb241a"},
+]
+
+[package.dependencies]
+anyascii = "*"
+pyahocorasick = "*"
 
 [[package]]
 name = "tomlkit"
@@ -2162,4 +2250,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "a12ab2befe68ba8f6a918f5568b9a308af7c3d954e982a39eacb4053088f726f"
+content-hash = "0f2e9082200eeb36ca502309770dcba911820fc9064cfad802a54b493c0f9ea3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ redis = { extras = ["hiredis"], version = "^5.0.7" }
 nltk = "^3.8.1"
 pydantic = "^2.8.2"
 redisvl = {extras = ["hiredis"], version = "^0.2.3"}
+contractions = "^0.1.73"
 
 [tool.poetry.dev-dependencies]
 commitizen = "3.27.0"


### PR DESCRIPTION
The tokenizer now handles contractions like `let's` and `gonna`.

## Changes
- Add step to tokenizer for expanding contractions.
- Refactor `word_frequency` function to use the built-in `collections.Counter` class.
- Add unit tests for the `courageous_comets.words` module.