### PR TITLE
refactor: move startup logic into bot class

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,9 @@
-import os
 from pathlib import Path
 
-import nltk
 import pytest
 import yaml
+
+from courageous_comets.nltk import init_nltk
 
 
 @pytest.fixture(scope="session")
@@ -14,13 +14,7 @@ def application_config() -> dict:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _load_nltk_data(application_config: dict) -> None:
+async def _load_nltk_data(application_config: dict) -> None:
     """Load the NLTK data for testing."""
     resources = application_config.get("nltk", [])
-
-    for resource in resources:
-        nltk.download(
-            resource,
-            quiet=True,
-            download_dir=os.getenv("NLTK_DATA", "nltk_data"),
-        )
+    await init_nltk(resources)

--- a/courageous_comets/__main__.py
+++ b/courageous_comets/__main__.py
@@ -1,118 +1,15 @@
 import asyncio
 import logging
-import sys
 
 import discord
-import nltk
-import redis.asyncio as redis
-import yaml
-from redisvl.index import AsyncSearchIndex
 
 from courageous_comets import bot, exceptions, settings
-from courageous_comets.redis import schema
-
-
-async def download_nltk_resource(resource: str, semaphore: asyncio.Semaphore) -> None:
-    """Download an NLTK resource to the specified directory."""
-    async with semaphore:
-        logging.debug("Downloading NLTK resource '%s'...", resource)
-        try:
-            await asyncio.to_thread(
-                nltk.download,
-                resource,
-                download_dir=settings.NLTK_DATA_DIR,
-                quiet=True,
-                raise_on_error=True,
-            )
-        except ValueError as e:
-            message = f"Invalid NLTK resource '{resource}'"
-            raise exceptions.NltkInitializationError(message) from e
-
-
-async def init_nltk() -> None:
-    """
-    Ensure all required NLTK resources are downloaded.
-
-    Downloads the resources specified in the bot configuration file.
-    """
-    with settings.BOT_CONFIG_PATH.open("r") as file:
-        config = yaml.safe_load(file)
-
-    resources = config.get("nltk", [])
-
-    semaphore = asyncio.Semaphore(settings.NLTK_DOWNLOAD_CONCURRENCY)
-    download_tasks = [download_nltk_resource(resource, semaphore) for resource in resources]
-
-    await asyncio.gather(*download_tasks)
-
-    logging.info("NLTK resources downloaded")
-
-
-async def create_indexes(redis: redis.Redis) -> None:
-    """Create search indexes on Redis."""
-    logging.debug("Creating indexes on redis...")
-
-    message_index = AsyncSearchIndex.from_dict(schema.MESSAGE_SCHEMA)
-    message_index.set_client(redis)
-
-    await message_index.create(overwrite=True)
-
-    logging.info("Created indexes on Redis")
-
-
-async def init_redis() -> redis.Redis:
-    """
-    Initialize the Redis connection.
-
-    Returns
-    -------
-    redis.asyncio.Redis
-        The Redis connection instance.
-
-    Raises
-    ------
-    courageous_comets.exceptions.AuthenticationError
-        If the Redis password is incorrect.
-    courageous_comets.exceptions.DatabaseConnectionError
-        If the connection to Redis cannot be established.
-    """
-    logging.debug("Connecting to Redis...")
-
-    instance = redis.Redis(
-        host=settings.REDIS_HOST,
-        port=settings.REDIS_PORT,
-        password=settings.REDIS_PASSWORD,
-    )
-
-    # Check if the connection is successful
-    try:
-        await instance.ping()
-    except redis.AuthenticationError as e:
-        message = "Redis authentication failed. Check the REDIS_PASSWORD environment variable."
-        raise exceptions.AuthenticationError(message) from e
-    except redis.RedisError as e:
-        message = f"Could not connect to Redis at {settings.REDIS_HOST}:{settings.REDIS_PORT}"
-        raise exceptions.DatabaseConnectionError(message) from e
-
-    logging.info(
-        "Connected to Redis at %s:%s",
-        settings.REDIS_HOST,
-        settings.REDIS_PORT,
-    )
-
-    # Create search indexes on Redis
-    await create_indexes(instance)
-
-    logging.info("Redis initialization complete")
-
-    return instance
 
 
 async def main() -> None:
     """
     Start the appication.
 
-    Handles the setup and teardown of the Discord client and Redis connection.
     If a critical error occurs, attempt to shut down gracefully.
 
     Raises
@@ -121,29 +18,17 @@ async def main() -> None:
         If the Discord token is not valid.
     """
     logging.info("Starting the Courageous Comets application ☄️")
-
-    # Initialize dependencies
-    redis = await init_redis()
-    await init_nltk()
-
     try:
-        logging.info("Starting the Discord client 🚀")
         await bot.start(settings.DISCORD_TOKEN)
-    except discord.LoginFailure as e:
-        message = "Discord login failed. Check the DISCORD_TOKEN environment variable."
-        raise exceptions.AuthenticationError(message) from e
+    except discord.LoginFailure:
+        logging.critical("Discord login failed. Check the DISCORD_TOKEN environment variable.")
+    except (exceptions.CourageousCometsError, discord.DiscordException) as e:
+        logging.critical(
+            "A fatal error occurred while running the Courageous Comets application.",
+            exc_info=e,
+        )
     finally:
-        logging.info("Shutting down gracefully...")
-        logging.debug("Closing Redis connection...")
-        await redis.aclose()
-        logging.info("Application shutdown complete. Goodbye! 👋")
+        await bot.close()
 
 
-try:
-    asyncio.run(main())
-except (exceptions.CourageousCometsError, discord.DiscordException) as e:
-    logging.critical(
-        "A fatal error occurred while running the bot.",
-        exc_info=e,
-    )
-    sys.exit(1)
+asyncio.run(main())

--- a/courageous_comets/nltk/__init__.py
+++ b/courageous_comets/nltk/__init__.py
@@ -1,0 +1,3 @@
+from .helpers import init_nltk
+
+__all__ = ["init_nltk"]

--- a/courageous_comets/nltk/helpers.py
+++ b/courageous_comets/nltk/helpers.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from pathlib import Path
 
 import nltk
 
@@ -31,6 +32,14 @@ async def init_nltk(resources: list[str]) -> None:
 
     Downloads the resources specified in the bot configuration file.
     """
+    if not any(resources):
+        logger.debug("No NLTK resources to download")
+        return
+
+    # Create the NLTK data directory if it does not exist to avoid a race condition when running
+    # multiple download tasks concurrently
+    Path(settings.NLTK_DATA_DIR).mkdir(parents=True, exist_ok=True)
+
     semaphore = asyncio.Semaphore(settings.NLTK_DOWNLOAD_CONCURRENCY)
     download_tasks = [download_nltk_resource(resource, semaphore) for resource in resources]
 

--- a/courageous_comets/nltk/helpers.py
+++ b/courageous_comets/nltk/helpers.py
@@ -1,0 +1,39 @@
+import asyncio
+import logging
+
+import nltk
+
+from courageous_comets import exceptions, settings
+
+logger = logging.getLogger(__name__)
+
+
+async def download_nltk_resource(resource: str, semaphore: asyncio.Semaphore) -> None:
+    """Download an NLTK resource to the specified directory."""
+    async with semaphore:
+        logger.debug("Downloading NLTK resource '%s'...", resource)
+        try:
+            await asyncio.to_thread(
+                nltk.download,
+                resource,
+                download_dir=settings.NLTK_DATA_DIR,
+                quiet=True,
+                raise_on_error=True,
+            )
+        except ValueError as e:
+            message = f"Invalid NLTK resource '{resource}'"
+            raise exceptions.NltkInitializationError(message) from e
+
+
+async def init_nltk(resources: list[str]) -> None:
+    """
+    Ensure all required NLTK resources are downloaded.
+
+    Downloads the resources specified in the bot configuration file.
+    """
+    semaphore = asyncio.Semaphore(settings.NLTK_DOWNLOAD_CONCURRENCY)
+    download_tasks = [download_nltk_resource(resource, semaphore) for resource in resources]
+
+    await asyncio.gather(*download_tasks)
+
+    logger.debug("NLTK resources downloaded")

--- a/courageous_comets/redis/__init__.py
+++ b/courageous_comets/redis/__init__.py
@@ -1,0 +1,3 @@
+from .helpers import init_redis
+
+__all__ = ["init_redis"]

--- a/courageous_comets/redis/helpers.py
+++ b/courageous_comets/redis/helpers.py
@@ -1,0 +1,67 @@
+import logging
+
+import redis.asyncio as redis
+from redisvl.index import AsyncSearchIndex
+
+from courageous_comets import exceptions, settings
+from courageous_comets.redis import schema
+
+logger = logging.getLogger(__name__)
+
+
+async def create_indexes(redis: redis.Redis) -> None:
+    """Create search indexes on Redis."""
+    logger.debug("Creating indexes on redis...")
+
+    message_index = AsyncSearchIndex.from_dict(schema.MESSAGE_SCHEMA)
+    message_index.set_client(redis)
+
+    await message_index.create(overwrite=True)
+
+    logger.debug("Created indexes on Redis")
+
+
+async def init_redis() -> redis.Redis:
+    """
+    Initialize the Redis connection.
+
+    Returns
+    -------
+    redis.asyncio.Redis
+        The Redis connection instance.
+
+    Raises
+    ------
+    courageous_comets.exceptions.AuthenticationError
+        If the Redis password is incorrect.
+    courageous_comets.exceptions.DatabaseConnectionError
+        If the connection to Redis cannot be established.
+    """
+    logger.debug("Connecting to Redis...")
+
+    instance = redis.Redis(
+        host=settings.REDIS_HOST,
+        port=settings.REDIS_PORT,
+        password=settings.REDIS_PASSWORD,
+    )
+
+    try:
+        await instance.ping()
+    except redis.AuthenticationError as e:
+        message = "Redis authentication failed. Check the REDIS_PASSWORD environment variable."
+        raise exceptions.AuthenticationError(message) from e
+    except redis.RedisError as e:
+        message = f"Could not connect to Redis at {settings.REDIS_HOST}:{settings.REDIS_PORT}"
+        raise exceptions.DatabaseConnectionError(message) from e
+
+    logger.debug(
+        "Connected to Redis at %s:%s",
+        settings.REDIS_HOST,
+        settings.REDIS_PORT,
+    )
+
+    await create_indexes(instance)
+
+    logger.debug("Redis initialization complete")
+
+    return instance

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -5,7 +5,6 @@ import os
 import sys
 from pathlib import Path
 
-from discord.utils import setup_logging
 from dotenv import load_dotenv
 
 from courageous_comets.exceptions import ConfigurationValueError
@@ -130,8 +129,6 @@ LOG_LEVEL = logging.getLevelNamesMapping().get(
     os.getenv("LOG_LEVEL", "INFO"),
     logging.INFO,
 )
-setup_logging(level=LOG_LEVEL)
-
 
 try:
     DISCORD_TOKEN = read_discord_token()

--- a/courageous_comets/test__client.py
+++ b/courageous_comets/test__client.py
@@ -46,7 +46,6 @@ def test__bot_has_required_intents(bot: CourageousCometsBot) -> None:
     assert bot.intents == intents
 
 
-@pytest.mark.asyncio()
 async def test__on_ready_logs_message(bot: CourageousCometsBot, mocker: MockerFixture) -> None:
     """
     Test whether the on_ready function logs the expected message.
@@ -60,7 +59,6 @@ async def test__on_ready_logs_message(bot: CourageousCometsBot, mocker: MockerFi
     logger_info.assert_called_with("Logged in as %s", mocker.ANY)
 
 
-@pytest.mark.asyncio()
 async def test__load_cogs_loads_all_cogs(bot: CourageousCometsBot, mocker: MockerFixture) -> None:
     """
     Test whether the load_cogs function loads all cogs from the config file.
@@ -79,7 +77,6 @@ async def test__load_cogs_loads_all_cogs(bot: CourageousCometsBot, mocker: Mocke
         load_extension.assert_any_call(cog)
 
 
-@pytest.mark.asyncio()
 async def test__load_cogs_logs_loaded_cogs(
     bot: CourageousCometsBot,
     mocker: MockerFixture,
@@ -104,7 +101,6 @@ async def test__load_cogs_logs_loaded_cogs(
         logger_debug.assert_any_call("Loaded cog %s", cog)
 
 
-@pytest.mark.asyncio()
 async def test__load_cogs_logs_exception_on_extension_error(
     bot: CourageousCometsBot,
     mocker: MockerFixture,
@@ -129,7 +125,6 @@ async def test__load_cogs_logs_exception_on_extension_error(
     logger_exception.assert_called_with("Failed to load cog %s", "cog1", exc_info=expected)
 
 
-@pytest.mark.asyncio()
 async def test__sync_syncs_to_current_guild(mock_context: MockType) -> None:
     """
     Test whether the sync command syncs to the current guild.
@@ -147,7 +142,6 @@ async def test__sync_syncs_to_current_guild(mock_context: MockType) -> None:
     )
 
 
-@pytest.mark.asyncio()
 async def test__sync_syncs_to_global_scope(mock_context: MockType) -> None:
     """
     Test whether the sync command syncs to the global scope.
@@ -165,7 +159,6 @@ async def test__sync_syncs_to_global_scope(mock_context: MockType) -> None:
     )
 
 
-@pytest.mark.asyncio()
 async def test__sync_removes_non_global_commands(mock_context: MockType) -> None:
     """
     Test whether the sync command removes non-global commands.
@@ -183,7 +176,6 @@ async def test__sync_removes_non_global_commands(mock_context: MockType) -> None
     mock_context.send.assert_awaited_with("Synced 0 command(s) to the current guild.")
 
 
-@pytest.mark.asyncio()
 async def test__sync_syncs_to_given_guilds(
     mocker: MockerFixture,
     mock_context: MockType,
@@ -206,7 +198,6 @@ async def test__sync_syncs_to_given_guilds(
     mock_context.send.assert_awaited_with(f"Synced the tree to {len(guilds)}/{len(guilds)}.")
 
 
-@pytest.mark.asyncio()
 async def test__sync_logs_exception_on_http_exception(
     mocker: MockerFixture,
     mock_context: MockType,

--- a/courageous_comets/test__sentiment.py
+++ b/courageous_comets/test__sentiment.py
@@ -67,7 +67,6 @@ def test__calculate_sentiment_truncates_long_messages(
     assert logger_warning.called == expected
 
 
-@pytest.mark.asyncio()
 async def test__store_sentiment_calculates_and_stores_sentiment(
     *,
     mocker: MockerFixture,
@@ -102,7 +101,6 @@ async def test__store_sentiment_calculates_and_stores_sentiment(
     )
 
 
-@pytest.mark.asyncio()
 async def test__store_sentiment_ignores_empty_messages(
     *,
     mocker: MockerFixture,
@@ -128,7 +126,6 @@ async def test__store_sentiment_ignores_empty_messages(
         Mock(content="test", guild=Mock(id=1), channel=Mock(id=1), author=None, id=1),
     ],
 )
-@pytest.mark.asyncio()
 async def test__store_sentiment_ignores_messages_without_ids(
     *,
     redis: MockType,
@@ -145,7 +142,6 @@ async def test__store_sentiment_ignores_messages_without_ids(
     redis.hset.assert_not_awaited()
 
 
-@pytest.mark.asyncio()
 async def test__get_sentiment_retrieves_sentiment_from_redis(
     *,
     redis: MockType,
@@ -173,7 +169,6 @@ async def test__get_sentiment_retrieves_sentiment_from_redis(
     assert result == expected
 
 
-@pytest.mark.asyncio()
 async def test__get_sentiment_handles_missing_sentiment(
     *,
     redis: MockType,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pyyaml = "^6.0.1"
 redis = { extras = ["hiredis"], version = "^5.0.7" }
 nltk = "^3.8.1"
 pydantic = "^2.8.2"
-redisvl = {extras = ["hiredis"], version = "^0.2.3"}
+redisvl = { extras = ["hiredis"], version = "^0.2.3" }
 contractions = "^0.1.73"
 
 [tool.poetry.dev-dependencies]
@@ -38,6 +38,7 @@ pythonVersion = "3.12"
 reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.pytest.ini_options]
+asyncio_mode = "auto"
 filterwarnings = [
     "ignore:'audioop' is deprecated and slated for removal in Python 3.13",
 ]


### PR DESCRIPTION
Move setup and teardown logic from `__main__` into the `courageous_comets.client.CourageousCometsBot` class.

## Changes
- Add back the class-based Discord Bot and implement  the `close` method
- Create `redis.helpers` and `nltk.helpers` modules with initialization logic
- Clean up `__main__.py`
- Update unit tests