### PR TITLE
fix: save messages with message_id on redis

### DIFF
--- a/courageous_comets/redis/keys.py
+++ b/courageous_comets/redis/keys.py
@@ -42,12 +42,12 @@ class KeySchema:
     """
 
     @prefix_key
-    def guild_messages(self, guild_id: int) -> str:
+    def guild_messages(self, *, guild_id: int | str, message_id: int | str) -> str:
         """Key to messages for a Discord guild.
 
         Redis type: hash
         """
-        return f"{guild_id}:messages"
+        return f"messages:{guild_id}:{message_id}"
 
     @prefix_key
     def guild_message_tokens(self, guild_id: int) -> str:
@@ -55,7 +55,7 @@ class KeySchema:
 
         Redis type: hash
         """
-        return f"{guild_id}:messages:tokens"
+        return f"messages:tokens:{guild_id}"
 
     @prefix_key
     def sentiment_tokens(
@@ -70,7 +70,7 @@ class KeySchema:
 
         Redis type: hash
         """
-        return f"{guild_id}:{channel_id}:{user_id}:{message_id}:sentiment"
+        return f"sentiment:{guild_id}:{channel_id}:{user_id}:{message_id}"
 
 
 key_schema = KeySchema()

--- a/courageous_comets/redis/messages.py
+++ b/courageous_comets/redis/messages.py
@@ -70,7 +70,8 @@ async def save_message(
             [message.model_dump()],
             keys=[
                 key_schema.guild_messages(
-                    message.guild_id,  # pyright: ignore
+                    guild_id=message.guild_id,
+                    message_id=message.message_id,
                 ),
             ],
         )

--- a/tests/courageous_comets/test__sentiment.py
+++ b/tests/courageous_comets/test__sentiment.py
@@ -6,6 +6,7 @@ from redis.asyncio import Redis
 
 from courageous_comets import settings
 from courageous_comets.models import SentimentResult
+from courageous_comets.redis.keys import key_schema
 from courageous_comets.sentiment import (
     MAX_MESSAGE_LENGTH,
     calculate_sentiment,
@@ -93,7 +94,7 @@ async def test__store_sentiment_calculates_and_stores_sentiment(
     await store_sentiment(message, redis)
 
     redis.hset.assert_awaited_with(
-        f"{settings.REDIS_KEYS_PREFIX}:1:1:1:1:sentiment",
+        key_schema.sentiment_tokens(1, 1, 1, 1),
         mapping={
             "neg": mocker.ANY,
             "neu": mocker.ANY,
@@ -155,7 +156,7 @@ async def test__get_sentiment_retrieves_sentiment_from_redis(
     -------
     - The sentiment is retrieved from the database.
     """
-    key = f"{settings.REDIS_KEYS_PREFIX}:1:1:1:1:sentiment"
+    key = key_schema.sentiment_tokens(1, 1, 1, 1)
     redis.hmget.return_value = ["1.0", "1.0", "1.0", "1.0"]
 
     expected = SentimentResult(

--- a/tests/courageous_comets/test__sentiment.py
+++ b/tests/courageous_comets/test__sentiment.py
@@ -4,7 +4,6 @@ import pytest
 from pytest_mock import MockerFixture, MockType
 from redis.asyncio import Redis
 
-from courageous_comets import settings
 from courageous_comets.models import SentimentResult
 from courageous_comets.redis.keys import key_schema
 from courageous_comets.sentiment import (
@@ -183,7 +182,7 @@ async def test__get_sentiment_handles_missing_sentiment(
     -------
     - The function returns default sentiment values when the sentiment is missing.
     """
-    key = f"{settings.REDIS_KEYS_PREFIX}:1:1:1:1:sentiment"
+    key = key_schema.sentiment_tokens(1, 1, 1, 1)
     redis.hmget.return_value = [None, None, None, None]
 
     expected = SentimentResult(

--- a/tests/integrations/test__messages.py
+++ b/tests/integrations/test__messages.py
@@ -36,7 +36,7 @@ async def test__messages_on_message__message_saved_to_redis(
 
     await cog.on_message(message)
 
-    key = key_schema.guild_messages(1)
+    key = key_schema.guild_messages(guild_id=1, message_id=1)
     key_exists = await redis.exists(key)
 
     assert key_exists

--- a/tests/integrations/test__redis.py
+++ b/tests/integrations/test__redis.py
@@ -57,7 +57,10 @@ async def test__save_message(
     - The returned key is the same as the one constructed by the key_schema
     """
     key = await save_message(redis, vectorized_message)
-    assert key == key_schema.guild_messages(int(vectorized_message.guild_id))
+    assert key == key_schema.guild_messages(
+        guild_id=vectorized_message.guild_id,
+        message_id=vectorized_message.message_id,
+    )
 
 
 async def test__get_similar_message(


### PR DESCRIPTION
# Changes

- save messages with message_id on Redis
- move variables to the end of each key generator method