### PR TITLE
refactor: include save_message in Messages cog

### DIFF
--- a/courageous_comets/client.py
+++ b/courageous_comets/client.py
@@ -33,7 +33,7 @@ class CourageousCometsBot(commands.Bot):
         The Redis connection instance for the bot, or `None` if not connected.
     """
 
-    redis: Redis
+    redis: Redis | None = None
 
     def __init__(self) -> None:
         super().__init__(

--- a/courageous_comets/client.py
+++ b/courageous_comets/client.py
@@ -7,6 +7,7 @@ import discord
 import yaml
 from discord import Intents
 from discord.ext import commands
+from redis.asyncio import Redis
 
 from courageous_comets import settings
 from courageous_comets.nltk import init_nltk
@@ -32,12 +33,13 @@ class CourageousCometsBot(commands.Bot):
         The Redis connection instance for the bot, or `None` if not connected.
     """
 
+    redis: Redis
+
     def __init__(self) -> None:
         super().__init__(
             command_prefix=commands.when_mentioned,
             intents=intents,
         )
-        self.redis = None
 
     @override
     async def close(self) -> None:


### PR DESCRIPTION
Convention is that stuff that operates on the bot stays in cogs. This PR moves `save_message()` into the Messages cog, removing the need to pass the redis connection and vectorizer as parameters