### PR TITLE
feat: add from_discord_message classmethod helper for creation of models.Message object

### DIFF
--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -6,7 +6,6 @@ from discord.ext import commands
 from courageous_comets.client import CourageousCometsBot
 from courageous_comets.models import VectorizedMessage
 from courageous_comets.redis import messages
-from courageous_comets.vectorizer import Vectorizer
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +15,6 @@ class Messages(commands.Cog):
 
     def __init__(self, bot: CourageousCometsBot) -> None:
         self.bot = bot
-        self.vectorizer = Vectorizer()
 
     @commands.Cog.listener(name="on_message")
     async def on_message(self, message: discord.Message) -> None:
@@ -53,17 +51,7 @@ class Messages(commands.Cog):
                 message.id,
             )
 
-        embedding = await self.vectorizer.aencode(message.content)
-
-        vectorized_message = VectorizedMessage(
-            user_id=str(message.author.id),
-            message_id=str(message.id),
-            channel_id=str(message.channel.id),
-            guild_id=str(message.guild.id),
-            content=message.content,
-            timestamp=message.created_at,
-            embedding=embedding,
-        )
+        vectorized_message = await VectorizedMessage.from_discord_message(message)
 
         key = await messages.save_message(self.bot.redis, vectorized_message)
 

--- a/courageous_comets/models.py
+++ b/courageous_comets/models.py
@@ -5,6 +5,8 @@ import discord
 import pydantic
 from pydantic import PlainSerializer
 
+from courageous_comets.vectorizer import Vectorizer
+
 UnixTimestamp = Annotated[
     datetime.datetime,
     PlainSerializer(lambda t: t.timestamp(), return_type=float),
@@ -76,6 +78,30 @@ class VectorizedMessage(Message):
     """
 
     embedding: bytes
+
+    @classmethod
+    async def from_discord_message(cls, message: discord.Message) -> Self:
+        """
+        Construct a Message model from a discord.Message object.
+
+        Parameters
+        ----------
+        message: discord.Message
+            The discord message to read data from
+        """
+        vectorizer = Vectorizer()
+
+        embedding = await vectorizer.aencode(message.content)
+
+        return cls(
+            message_id=str(message.id),
+            channel_id=str(message.channel.id),
+            guild_id=str(message.guild.id),  # type: ignore
+            timestamp=message.created_at,
+            user_id=str(message.author.id),
+            content=message.content,
+            embedding=embedding,
+        )
 
 
 class SentimentResult(BaseModel):

--- a/courageous_comets/models.py
+++ b/courageous_comets/models.py
@@ -1,6 +1,7 @@
 import datetime
-from typing import Annotated
+from typing import Annotated, Self
 
+import discord
 import pydantic
 from pydantic import PlainSerializer
 
@@ -43,6 +44,25 @@ class Message(BaseModel):
     timestamp: UnixTimestamp
     user_id: str
     content: str
+
+    @classmethod
+    def from_discord_message(cls, message: discord.Message) -> Self:
+        """
+        Construct a Message model from a discord.Message object.
+
+        Parameters
+        ----------
+        message: discord.Message
+            The discord message to read data from
+        """
+        return cls(
+            message_id=str(message.id),
+            channel_id=str(message.channel.id),
+            guild_id=str(message.guild.id),  # type: ignore
+            timestamp=message.created_at,
+            user_id=str(message.author.id),
+            content=message.content,
+        )
 
 
 class VectorizedMessage(Message):


### PR DESCRIPTION
This PR adds an alternative way to construct a models.Message and models.VectorizedMessage from a discord.Message object.