### PR TITLE
feat: store sentiment analysis with message data

### DIFF
--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -83,6 +83,7 @@ class Messages(commands.Cog):
                 timestamp=message.created_at,
                 embedding=embedding,
                 sentiment=calculate_sentiment(message.content),
+            ),
         )
 
         return logger.info(

--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -82,7 +82,7 @@ class Messages(commands.Cog):
                 guild_id=str(message.guild.id),  # pyright: ignore
                 timestamp=message.created_at,
                 embedding=embedding,
-                sentiment=calculate_sentiment(message.content),
+                sentiment=calculate_sentiment(text),
             ),
         )
 

--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -4,8 +4,9 @@ import discord
 from discord.ext import commands
 
 from courageous_comets.client import CourageousCometsBot
-from courageous_comets.models import VectorizedMessage
+from courageous_comets.models import MessageAnalysis
 from courageous_comets.redis import messages
+from courageous_comets.sentiment import calculate_sentiment
 from courageous_comets.vectorizer import Vectorizer
 
 logger = logging.getLogger(__name__)
@@ -46,26 +47,36 @@ class Messages(commands.Cog):
                 "Ignoring message %s because the bot is not connected to Redis",
                 message.id,
             )
+        # Ignore empty messages
+        if not message.content:
+            logger.warning("Ignoring empty message %s", message.id)
+            return None
 
-        if not message.guild:
-            return logger.debug(
-                "Ignoring message %s because it's not in a guild",
-                message.id,
-            )
+        # Extract the IDs from the message
+        guild_id = message.guild.id if message.guild else 0
+        channel_id = message.channel.id if message.channel else 0
+        user_id = message.author.id if message.author else 0
+        message_id = message.id if message.id else 0
+
+        # Ignore messages without all required IDs
+        if not all((guild_id, channel_id, user_id, message_id)):
+            logger.warning("Ignoring message %s with missing IDs", message.id)
+            return None
 
         embedding = await self.vectorizer.aencode(message.content)
 
-        vectorized_message = VectorizedMessage(
-            user_id=str(message.author.id),
-            message_id=str(message.id),
-            channel_id=str(message.channel.id),
-            guild_id=str(message.guild.id),
-            content=message.content,
-            timestamp=message.created_at,
-            embedding=embedding,
+        key = await messages.save_message(
+            self.bot.redis,
+            MessageAnalysis(
+                user_id=str(message.author.id),
+                message_id=str(message.id),
+                channel_id=str(message.channel.id),
+                guild_id=str(message.guild.id),  # pyright: ignore
+                timestamp=message.created_at,
+                embedding=embedding,
+                sentiment=calculate_sentiment(message.content),
+            ),
         )
-
-        key = await messages.save_message(self.bot.redis, vectorized_message)
 
         return logger.info(
             "Saved message %s to Redis with key %s",

--- a/courageous_comets/models.py
+++ b/courageous_comets/models.py
@@ -33,8 +33,6 @@ class Message(BaseModel):
         The timestamp when the message was sent.
     user_id : str
         The ID of the user who sent the message.
-    content : str
-        The content of the message.
     """
 
     message_id: str
@@ -42,20 +40,18 @@ class Message(BaseModel):
     guild_id: str
     timestamp: UnixTimestamp
     user_id: str
-    content: str
 
 
 class VectorizedMessage(Message):
-    """Message with vector embedding of content.
+    """Message with embedding vector of content.
 
     Attributes
     ----------
-    embedding : bytes
-        The embedding of the content.
-    embedding: bytes
+    embedding : list[float]
+        The embedding vector of the message content.
     """
 
-    embedding: bytes
+    embedding: list[float]
 
 
 class SentimentResult(BaseModel):
@@ -78,3 +74,15 @@ class SentimentResult(BaseModel):
     neu: float
     pos: float
     compound: float
+
+
+class MessageAnalysis(VectorizedMessage):
+    """Vectorized message with sentiment analysis.
+
+    Attributes
+    ----------
+    sentiment : SentimentResult
+        The results of sentiment analysis.
+    """
+
+    sentiment: SentimentResult

--- a/courageous_comets/redis/messages.py
+++ b/courageous_comets/redis/messages.py
@@ -47,7 +47,7 @@ async def update_message_tokens(
 
 async def save_message(
     redis: Redis,
-    message: models.VectorizedMessage,
+    message: models.MessageAnalysis,
 ) -> str:
     """Save a message on Redis.
 
@@ -55,7 +55,7 @@ async def save_message(
     ----------
     redis : Redis
         The Redis connection instance.
-    message : models.VectorizedMessage
+    message : models.MessageAnalysis
         The message to save
 
     Returns
@@ -80,8 +80,7 @@ async def save_message(
 
 async def get_similar_messages(
     redis: Redis,
-    message: models.Message,
-    embedding: bytes,
+    message: models.VectorizedMessage,
     limit: int = 10,
     scope: StatisticScopeEnum = StatisticScopeEnum.GUILD,
 ) -> list[models.Message]:
@@ -121,13 +120,12 @@ async def get_similar_messages(
             raise ValueError(error_message)
 
     query = VectorQuery(
-        vector=embedding,
+        vector=message.embedding,
         vector_field_name="embedding",
         return_fields=[
             "message_id",
             "channel_id",
             "user_id",
-            "content",
             "guild_id",
             "timestamp",
         ],

--- a/courageous_comets/redis/schema.py
+++ b/courageous_comets/redis/schema.py
@@ -4,6 +4,7 @@ MESSAGE_SCHEMA = {
     "index": {
         "name": "message_idx",
         "prefix": settings.REDIS_KEYS_PREFIX,
+        "storage_type": "json",
     },
     "fields": [
         {"name": "content", "type": "text"},
@@ -22,5 +23,9 @@ MESSAGE_SCHEMA = {
                 "datatype": "float32",
             },
         },
+        {"name": "neu", "type": "numeric", "path": "$.sentiment.neu"},
+        {"name": "neg", "type": "numeric", "path": "$.sentiment.neg"},
+        {"name": "pos", "type": "numeric", "path": "$.sentiment.pos"},
+        {"name": "compound", "type": "numeric", "path": "$.sentiment.compound"},
     ],
 }

--- a/courageous_comets/sentiment.py
+++ b/courageous_comets/sentiment.py
@@ -1,18 +1,15 @@
 import logging
 
-from discord import Message
 from nltk.sentiment import SentimentIntensityAnalyzer
-from redis.asyncio import Redis
 
 from courageous_comets.models import SentimentResult
-from courageous_comets.redis.keys import key_schema
 
 MAX_MESSAGE_LENGTH = 256
 
 logger = logging.getLogger(__name__)
 
 
-def calculate_sentiment(content: str, key: str) -> SentimentResult:
+def calculate_sentiment(content: str) -> SentimentResult:
     """
     Calculate the sentiment of a message.
 
@@ -25,8 +22,6 @@ def calculate_sentiment(content: str, key: str) -> SentimentResult:
     ----------
     content : str
         The message content to analyze.
-    key : str
-        The Redis key for the message. Used for logging.
 
     Returns
     -------
@@ -36,87 +31,9 @@ def calculate_sentiment(content: str, key: str) -> SentimentResult:
     truncated = content[:MAX_MESSAGE_LENGTH]
 
     if truncated != content:
-        logger.warning("Truncated message %s to %s characters", key, MAX_MESSAGE_LENGTH)
+        logger.warning("Truncated message to %s characters", MAX_MESSAGE_LENGTH)
 
     sia = SentimentIntensityAnalyzer()
     result = sia.polarity_scores(truncated)
 
     return SentimentResult.model_validate(result)
-
-
-async def store_sentiment(message: Message, redis: Redis) -> None:
-    """
-    Calculate the sentiment of a message and store the result in Redis.
-
-    A message must have a guild, channel, author and message ID. If any of these are missing,
-    the message will be ignored.
-
-    Empty messages will also be ignored.
-
-    Parameters
-    ----------
-    message : discord.Message
-        The message to process.
-    redis : redis.asyncio.Redis
-        The Redis connection instance.
-    """
-    # Ignore empty messages
-    if not message.content:
-        logger.warning("Ignoring empty message %s", message.id)
-        return
-
-    # Extract the IDs from the message
-    guild_id = message.guild.id if message.guild else 0
-    channel_id = message.channel.id if message.channel else 0
-    user_id = message.author.id if message.author else 0
-    message_id = message.id if message.id else 0
-
-    # Ignore messages without all required IDs
-    if not all((guild_id, channel_id, user_id, message_id)):
-        logger.warning("Ignoring message %s with missing IDs", message.id)
-        return
-
-    # Construct the Redis key
-    key = key_schema.sentiment_tokens(
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        message_id=message_id,
-    )
-
-    # Calculate the sentiment
-    sentiment = calculate_sentiment(message.content, key)
-
-    # Store the sentiment in Redis
-    await redis.hset(
-        key,
-        mapping=sentiment.model_dump(mode="json"),
-    )  # pyright: ignore[reportGeneralTypeIssues]
-
-    logger.info("Stored sentiment for message %s", key)
-
-
-async def get_sentiment(key: str, redis: Redis) -> SentimentResult:
-    """
-    Retrieve the sentiment of a message from Redis.
-
-    Parameters
-    ----------
-    key : str
-        The Redis key to retrieve the sentiment from.
-    redis : redis.asyncio.Redis
-        The Redis connection instance.
-
-    Returns
-    -------
-    courageous_comets.models.SentimentResult
-        The sentiment of the message.
-    """
-    neg, neu, pos, compound = await redis.hmget(key, "neg", "neu", "pos", "compound")  # type: ignore
-
-    return SentimentResult(
-        neg=float(neg or 0),
-        neu=float(neu or 0),
-        pos=float(pos or 0),
-        compound=float(compound or 0),
-    )

--- a/courageous_comets/vectorizer.py
+++ b/courageous_comets/vectorizer.py
@@ -37,7 +37,7 @@ class Vectorizer:
             cache_dir=settings.HF_HOME,
         )
 
-    def encode(self, message: str) -> bytes:
+    def encode(self, message: str) -> list[float]:
         """
         Create vector embedding of a message.
 
@@ -57,7 +57,7 @@ class Vectorizer:
 
         Returns
         -------
-        bytes
+        list[float]
             The vector embeddings of the message
         """
 
@@ -97,9 +97,9 @@ class Vectorizer:
             torch_nn_functional.normalize(sentence_embeddings, p=2, dim=1)
             .numpy()
             .astype(np.float32)
-            .tobytes()
+            .tolist()[0]
         )
 
-    async def aencode(self, message: str) -> bytes:
+    async def aencode(self, message: str) -> list[float]:
         """Create a vector embedding of message asynchronously."""
         return await asyncio.to_thread(self.encode, message)

--- a/tests/courageous_comets/test__sentiment.py
+++ b/tests/courageous_comets/test__sentiment.py
@@ -1,17 +1,12 @@
-from unittest.mock import Mock
-
 import pytest
-from pytest_mock import MockerFixture, MockType
+from pytest_mock import MockerFixture
 from redis.asyncio import Redis
 
 from courageous_comets.models import SentimentResult
-from courageous_comets.redis.keys import key_schema
 from courageous_comets.sentiment import (
     MAX_MESSAGE_LENGTH,
     calculate_sentiment,
-    get_sentiment,
     logger,
-    store_sentiment,
 )
 
 
@@ -40,7 +35,7 @@ def test__calculate_sentiment_analyzes_sentiment_of_given_text(
         pos=mocker.ANY,
         compound=mocker.ANY,
     )
-    result = calculate_sentiment("I love this product!", "test")
+    result = calculate_sentiment("I love this product!")
     assert result == expected
 
 
@@ -65,134 +60,5 @@ def test__calculate_sentiment_truncates_long_messages(
     - The function truncates messages longer than 256 characters.
     """
     logger_warning = mocker.spy(logger, "warning")
-    calculate_sentiment(message, "test")
+    calculate_sentiment(message)
     assert logger_warning.called == expected
-
-
-async def test__store_sentiment_calculates_and_stores_sentiment(
-    *,
-    mocker: MockerFixture,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function calculates and stores the sentiment of a message.
-
-    Asserts
-    -------
-    - The sentiment is calculated for the message content.
-    - The sentiment is stored in the database.
-    """
-    message = mocker.Mock(
-        content="I love this product!",
-        guild=Mock(id=1),
-        channel=Mock(id=1),
-        author=Mock(id=1),
-        id=1,
-    )
-
-    await store_sentiment(message, redis)
-
-    redis.hset.assert_awaited_with(
-        key_schema.sentiment_tokens(1, 1, 1, 1),
-        mapping={
-            "neg": mocker.ANY,
-            "neu": mocker.ANY,
-            "pos": mocker.ANY,
-            "compound": mocker.ANY,
-        },
-    )
-
-
-async def test__store_sentiment_ignores_empty_messages(
-    *,
-    mocker: MockerFixture,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function ignores empty messages.
-
-    Asserts
-    -------
-    - The database is not updated when the message is empty.
-    """
-    message = mocker.Mock(content="")
-    await store_sentiment(message, redis)
-    redis.hset.assert_not_awaited()
-
-
-@pytest.mark.parametrize(
-    "message",
-    [
-        Mock(content="test", guild=None, channel=None, author=None, id=1),
-        Mock(content="test", guild=Mock(id=1), channel=None, author=None, id=1),
-        Mock(content="test", guild=Mock(id=1), channel=Mock(id=1), author=None, id=1),
-    ],
-)
-async def test__store_sentiment_ignores_messages_without_ids(
-    *,
-    redis: MockType,
-    message: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function ignores messages without IDs.
-
-    Asserts
-    -------
-    - The database is not updated when the message is missing IDs.
-    """
-    await store_sentiment(message, redis)
-    redis.hset.assert_not_awaited()
-
-
-async def test__get_sentiment_retrieves_sentiment_from_redis(
-    *,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the get sentiment function retrieves the sentiment of a message from Redis.
-
-    Asserts
-    -------
-    - The sentiment is retrieved from the database.
-    """
-    key = key_schema.sentiment_tokens(1, 1, 1, 1)
-    redis.hmget.return_value = ["1.0", "1.0", "1.0", "1.0"]
-
-    expected = SentimentResult(
-        neg=1.0,
-        neu=1.0,
-        pos=1.0,
-        compound=1.0,
-    )
-
-    result = await get_sentiment(key, redis)
-
-    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
-    assert result == expected
-
-
-async def test__get_sentiment_handles_missing_sentiment(
-    *,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the get sentiment function handles missing sentiment in Redis.
-
-    Asserts
-    -------
-    - The function returns default sentiment values when the sentiment is missing.
-    """
-    key = key_schema.sentiment_tokens(1, 1, 1, 1)
-    redis.hmget.return_value = [None, None, None, None]
-
-    expected = SentimentResult(
-        neg=0.0,
-        neu=0.0,
-        pos=0.0,
-        compound=0.0,
-    )
-
-    result = await get_sentiment(key, redis)
-
-    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
-    assert expected == result

--- a/tests/integrations/test__redis.py
+++ b/tests/integrations/test__redis.py
@@ -1,53 +1,55 @@
 import datetime
 
-import pytest
 import pytest_asyncio
 from redis.asyncio import Redis
 
 from courageous_comets import models
 from courageous_comets.redis.keys import key_schema
 from courageous_comets.redis.messages import get_similar_messages, save_message
+from courageous_comets.sentiment import calculate_sentiment
 from courageous_comets.vectorizer import Vectorizer
 
 
-@pytest.fixture(scope="session")
-def message() -> models.Message:
-    """Fixture that sets up a message.
+@pytest_asyncio.fixture(scope="session")
+async def message(vectorizer: Vectorizer) -> models.MessageAnalysis:
+    """Fixture that sets up an analysis of a discord message.
 
     Returns
     -------
     models.Message
         A Redis model of a Discord message
     """
-    return models.Message(
+    content = "The quick brown fox jumps over the lazy dog."
+    embedding = await vectorizer.aencode(content)
+    return models.MessageAnalysis(
         message_id="1",
         channel_id="1",
         guild_id="1",
         timestamp=datetime.datetime.fromtimestamp(0, datetime.UTC),
+        embedding=embedding,
         user_id="1",
-        content="The quick brown fox jumps over the lazy dog.",
+        sentiment=calculate_sentiment(content),
     )
 
 
 @pytest_asyncio.fixture(scope="session")
 async def vectorized_message(
-    message: models.Message,
-    vectorizer: Vectorizer,
+    message: models.MessageAnalysis,
 ) -> models.VectorizedMessage:
-    """Fixture that creates an embedding vector of contents of message.
+    """Fixture that creates a models.VectorizedMessage.
 
     Returns
     -------
     models.VectorizedMessage
         A message with embedding vector
     """
-    embedding = await vectorizer.aencode(message.content)
-    return models.VectorizedMessage(**message.model_dump(), embedding=embedding)
+    # NOTE: This works because BaseModel ignores extra fields
+    return models.VectorizedMessage(**message.model_dump())
 
 
 async def test__save_message(
     redis: Redis,
-    vectorized_message: models.VectorizedMessage,
+    message: models.MessageAnalysis,
 ) -> None:
     """
     Tests whether the save_mesage function stores the message on Redis.
@@ -56,16 +58,16 @@ async def test__save_message(
     -------
     - The returned key is the same as the one constructed by the key_schema
     """
-    key = await save_message(redis, vectorized_message)
+    key = await save_message(redis, message)
     assert key == key_schema.guild_messages(
-        guild_id=vectorized_message.guild_id,
-        message_id=vectorized_message.message_id,
+        guild_id=message.guild_id,
+        message_id=message.message_id,
     )
 
 
 async def test__get_similar_message(
     redis: Redis,
-    message: models.Message,
+    message: models.MessageAnalysis,
     vectorized_message: models.VectorizedMessage,
 ) -> None:
     """
@@ -75,7 +77,11 @@ async def test__get_similar_message(
     -------
     - The returned message is the same message whose embedding vector was used
     """
-    await save_message(redis, vectorized_message)
-    messages = await get_similar_messages(redis, message, vectorized_message.embedding)
+    await save_message(redis, message)
+    messages = await get_similar_messages(redis, vectorized_message)
     assert len(messages) == 1
-    assert messages[0].model_dump() == message.model_dump()
+    redis_message = messages[0]
+    assert redis_message.channel_id == message.channel_id
+    assert redis_message.guild_id == message.guild_id
+    assert redis_message.message_id == message.message_id
+    assert message.timestamp == message.timestamp


### PR DESCRIPTION
# BREAKING CHANGE

- Store messages as json instead of hash on Redis
- return a list of floats from vectorizer instead of bytes
- remove message content from Redis
- remove Redis interactions from `sentiment.py` since it would be stored along with the message
- create superclass of `VectorizedMessage` which contains the sentiment result. Allows the client to make calls to the db without creating both embeddings and analysis (except during `save_message` calls)
- refactor tests to account for the breaking changes