### PR TITLE
feat: set up message content preprocessing

### DIFF
--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -3,6 +3,7 @@ import logging
 import discord
 from discord.ext import commands
 
+from courageous_comets import preprocessing
 from courageous_comets.client import CourageousCometsBot
 from courageous_comets.models import VectorizedMessage
 from courageous_comets.redis import messages
@@ -53,14 +54,22 @@ class Messages(commands.Cog):
                 message.id,
             )
 
-        embedding = await self.vectorizer.embed(message.content)
+        text = preprocessing.process(message.clean_content)
+
+        if not text:
+            return logger.debug(
+                "Ignoring message %s because it's empty after processing",
+                message.id,
+            )
+
+        embedding = await self.vectorizer.embed(text)
 
         vectorized_message = VectorizedMessage(
             user_id=str(message.author.id),
             message_id=str(message.id),
             channel_id=str(message.channel.id),
             guild_id=str(message.guild.id),
-            content=message.content,
+            content=text,
             timestamp=message.created_at,
             embedding=embedding,
         )

--- a/courageous_comets/preprocessing.py
+++ b/courageous_comets/preprocessing.py
@@ -1,4 +1,5 @@
 import re
+import string
 from collections.abc import Callable
 from functools import partial
 
@@ -25,6 +26,23 @@ def drop_links(text: str) -> str:
         The text with links removed.
     """
     return re.sub(r"http\S+", "", text)
+
+
+def drop_punctuation(text: str) -> str:
+    """
+    Remove punctuation from the given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to process.
+
+    Returns
+    -------
+    str
+        The text without punctuation.
+    """
+    return text.translate(str.maketrans("", "", string.punctuation))
 
 
 def drop_very_long_words(text: str, max_length: int) -> str:
@@ -70,6 +88,7 @@ PROCESSORS: list[Processor] = [
     drop_links,
     unidecode,
     contractions.fix,  # type: ignore
+    drop_punctuation,
     partial(drop_very_long_words, max_length=settings.PREPROCESSING_MAX_WORD_LENGTH),
     partial(truncate, max_length=settings.PREPROCESSING_MAX_WORD_LENGTH),
 ]

--- a/courageous_comets/preprocessing.py
+++ b/courageous_comets/preprocessing.py
@@ -1,0 +1,99 @@
+import re
+from collections.abc import Callable
+from functools import partial
+
+import contractions
+from unidecode import unidecode
+
+from courageous_comets import settings
+
+Processor = Callable[[str], str]
+
+
+def drop_links(text: str) -> str:
+    """
+    Remove links from the given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to process.
+
+    Returns
+    -------
+    str
+        The text with links removed.
+    """
+    return re.sub(r"http\S+", "", text)
+
+
+def drop_very_long_words(text: str, max_length: int) -> str:
+    """
+    Remove very long words from the given text.
+
+    Parameters
+    ----------
+    text : str
+        The text to process.
+    max_length : int
+        The maximum length of a word to keep.
+
+    Returns
+    -------
+    str
+        The text with very long words removed.
+    """
+    return re.sub(r"\S{%d,}" % max_length, "", text)
+
+
+def truncate(text: str, max_length: int) -> str:
+    """
+    Truncate the given text to the specified length.
+
+    Parameters
+    ----------
+    text : str
+        The text to truncate.
+    max_length : int
+        The maximum length of the text.
+
+    Returns
+    -------
+    str
+        The truncated text.
+    """
+    return text[:max_length]
+
+
+# Steps are executed in order
+PROCESSORS: list[Processor] = [
+    drop_links,
+    unidecode,
+    contractions.fix,  # type: ignore
+    partial(drop_very_long_words, max_length=settings.PREPROCESSING_MAX_WORD_LENGTH),
+    partial(truncate, max_length=settings.PREPROCESSING_MAX_WORD_LENGTH),
+]
+
+
+def process(text: str, processors: list[Processor] = PROCESSORS) -> str:
+    """
+    Process the text using all available processors.
+
+    Parameters
+    ----------
+    text : str
+        The text to process.
+    processors : list[Processor], optional
+        The processors to use, by default uses a predefined set of processors.
+
+    Returns
+    -------
+    str
+        The processed text.
+    """
+    result = text
+
+    for processor in processors:
+        text = processor(result)
+
+    return result

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -154,6 +154,8 @@ try:
     BOT_CONFIG_PATH = read_bot_config_path()
     NLTK_DATA_DIR = os.getenv("NLTK_DATA", "nltk_data")
     NLTK_DOWNLOAD_CONCURRENCY = read_int("NLTK_DOWNLOAD_CONCURRENCY", 3)
+    PREPROCESSING_MAX_WORD_LENGTH = read_int("MAX_WORD_LENGTH", 35)
+    PREPROCESSING_MESSAGE_TRUNCATE_LENGTH = read_int("TRUNCATE_LENGTH", 256)
     REDIS_HOST = os.getenv("REDIS_HOST", "localhost")
     REDIS_PORT = read_redis_port()
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")

--- a/poetry.lock
+++ b/poetry.lock
@@ -2122,6 +2122,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2129,8 +2130,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2147,6 +2156,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2154,6 +2164,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2991,6 +3002,17 @@ files = [
 ]
 
 [[package]]
+name = "unidecode"
+version = "1.3.8"
+description = "ASCII transliterations of Unicode text"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
+    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.2.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -3231,4 +3253,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "6f3cea24ee781437f22206b6c78dc82869aacc270306d0950c3771078af09904"
+content-hash = "e8a7306e379d5b38a8a1a83461e521759c3d7017ba6406399713a4fbb22222ab"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2885,4 +2885,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12"
-content-hash = "2cc54b2bb53aef9e040db3e393d97f766eb5685c91c205472f65188a9787ac3b"
+content-hash = "0b8a8a895ed65e8231b563269fc9a778de7d90b0f2d25ad9eb7bd59b3c1802a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ redis = { extras = ["hiredis"], version = "5.0.7" }
 redisvl = { extras = ["hiredis"], version = "0.2.3" }
 sentence-transformers = "3.0.1"
 numpy = "^2.0.1"
+unidecode = "^1.3.8"
 
 [tool.poetry.dev-dependencies]
 commitizen = "3.27.0"

--- a/tests/courageous_comets/test__preprocessing.py
+++ b/tests/courageous_comets/test__preprocessing.py
@@ -1,0 +1,100 @@
+import pytest
+
+from courageous_comets.preprocessing import drop_links, drop_punctuation, drop_very_long_words
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Hello, world!", "Hello, world!"),
+        ("Hello, http://world.com!", "Hello, "),
+        ("Hello, https://world.com! How are you?", "Hello,  How are you?"),
+    ],
+)
+def test__drop_links(text: str, expected: str) -> None:
+    """
+    Test whether `drop_links` removes links from the given text.
+
+    Asserts
+    -------
+    - Links are removed from the given text.
+    - Text without links is not modified.
+    """
+    assert drop_links(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "Hello, world!",
+            "Hello world",
+        ),
+        (
+            "Testing... 1, 2, 3.",
+            "Testing 1 2 3",
+        ),
+        (
+            "No punctuation here",
+            "No punctuation here",
+        ),
+        (
+            "Special characters: @#&*()",
+            "Special characters ",
+        ),
+        (
+            "Mixed punctuation! How's it going?",
+            "Mixed punctuation Hows it going",
+        ),
+        (
+            "End with punctuation.",
+            "End with punctuation",
+        ),
+        (
+            "Multiple spaces   and punctuation!!!",
+            "Multiple spaces   and punctuation",
+        ),
+        (
+            "Punctuation-in-the-middle.",
+            "Punctuationinthemiddle",
+        ),
+        (
+            "12345!@#$%",
+            "12345",
+        ),
+        (
+            "Quotes 'single' and \"double\"",
+            "Quotes single and double",
+        ),
+    ],
+)
+def test__drop_punctuation(text: str, expected: str) -> None:
+    """
+    Test whether `drop_punctuation` removes punctuation from the given text.
+
+    Asserts
+    -------
+    - Punctuation is removed from the given text.
+    - Text without punctuation is not modified.
+    """
+    assert drop_punctuation(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Hello, world!", "Hello, world!"),
+        ("Hello, verylongword!", "Hello, "),
+        ("Hello, verylongword! How are you?", "Hello,  How are you?"),
+    ],
+)
+def test__drop_very_long_word(text: str, expected: str) -> None:
+    """
+    Test whether `drop_very_long_words` removes very long words from the given text.
+
+    Asserts
+    -------
+    - Very long words are removed from the given text.
+    - Text without very long words is not modified.
+    """
+    assert drop_very_long_words(text, max_length=10) == expected

--- a/tests/integrations/test__messages.py
+++ b/tests/integrations/test__messages.py
@@ -28,7 +28,7 @@ async def test__messages_on_message__message_saved_to_redis(
     """
     message = mocker.MagicMock(spec=discord.Message)
 
-    message.content = "The quick brown fox jumps over the lazy dog."
+    message.clean_content = "The quick brown fox jumps over the lazy dog."
     message.id = 1
     message.author.id = 1
     message.channel.id = 1


### PR DESCRIPTION
Add preprocessing steps to clean message data. The following processors are included:

- `drop_links` removes links from the messages
- `unidecode` replaces special characters and diacritics with standard unicode characters
- `contractions.fix` expands contractions like don't and gonna
- `drop_punctuation` removes all punctuation from the text
- `drop_very_long_words` removes words above a certain length
- `truncate` limits the length of a message to a given upper bound

The `courageous_comets.preprocessing` module also includes a `process` function that by default applies all of the above processing steps, but can be customized if needed. 