### PR TITLE
feat: store sentiment results along with message

### DIFF
--- a/courageous_comets/cogs/messages.py
+++ b/courageous_comets/cogs/messages.py
@@ -7,6 +7,7 @@ from courageous_comets import preprocessing
 from courageous_comets.client import CourageousCometsBot
 from courageous_comets.models import VectorizedMessage
 from courageous_comets.redis import messages
+from courageous_comets.sentiment import calculate_sentiment
 from courageous_comets.vectorizer import Vectorizer
 
 logger = logging.getLogger(__name__)
@@ -63,6 +64,7 @@ class Messages(commands.Cog):
             )
 
         embedding = await self.vectorizer.aencode(text)
+        sentiment = calculate_sentiment(text)
 
         vectorized_message = VectorizedMessage(
             user_id=str(message.author.id),
@@ -73,7 +75,7 @@ class Messages(commands.Cog):
             embedding=embedding,
         )
 
-        key = await messages.save_message(self.bot.redis, vectorized_message)
+        key = await messages.save_message(self.bot.redis, vectorized_message, sentiment)
 
         return logger.info(
             "Saved message %s to Redis with key %s",

--- a/courageous_comets/models.py
+++ b/courageous_comets/models.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Annotated
 
 import pydantic
-from pydantic import PlainSerializer
+from pydantic import Field, PlainSerializer
 
 UnixTimestamp = Annotated[
     datetime.datetime,
@@ -71,7 +71,7 @@ class SentimentResult(BaseModel):
         The compound sentiment score.
     """
 
-    neg: float
-    neu: float
-    pos: float
-    compound: float
+    neg: float = Field(..., serialization_alias="sentiment_neg")
+    neu: float = Field(..., serialization_alias="sentiment_neu")
+    pos: float = Field(..., serialization_alias="sentiment_pos")
+    compound: float = Field(..., serialization_alias="sentiment_compound")

--- a/courageous_comets/redis/keys.py
+++ b/courageous_comets/redis/keys.py
@@ -57,20 +57,5 @@ class KeySchema:
         """
         return f"messages:tokens:{guild_id}"
 
-    @prefix_key
-    def sentiment_tokens(
-        self,
-        guild_id: int,
-        channel_id: int,
-        user_id: int,
-        message_id: int,
-    ) -> str:
-        """
-        Key to sentiment tokens for a message.
-
-        Redis type: hash
-        """
-        return f"sentiment:{guild_id}:{channel_id}:{user_id}:{message_id}"
-
 
 key_schema = KeySchema()

--- a/courageous_comets/redis/messages.py
+++ b/courageous_comets/redis/messages.py
@@ -1,12 +1,44 @@
 from redis.asyncio import Redis
 from redisvl.index import AsyncSearchIndex
-from redisvl.query import VectorQuery
-from redisvl.query.filter import Tag
+from redisvl.query import FilterQuery, VectorQuery
+from redisvl.query.filter import FilterExpression, Num, Tag
 
-from courageous_comets import models
+from courageous_comets import models, settings
 from courageous_comets.enums import StatisticScopeEnum
 from courageous_comets.redis import schema
 from courageous_comets.redis.keys import key_schema
+
+
+def get_search_scope(
+    scope: StatisticScopeEnum,
+    message: models.Message,
+) -> FilterExpression:
+    """Determine the scope of a search.
+
+    Parameters
+    ----------
+    scope : courageous_comets.enums.StatisticScopeEnum
+        The scope of a search.
+    message : courageous_comets.models.Message
+        The comparison message.
+
+    Returns
+    -------
+    redisvl.query.FilterExpression
+        The redis filter expression for the specified scope
+
+    """
+    match scope:
+        case StatisticScopeEnum.GUILD:
+            filter_expression = Tag("guild_id") == message.guild_id
+        case StatisticScopeEnum.CHANNEL:
+            filter_expression = Tag("channel_id") == message.channel_id
+        case StatisticScopeEnum.USER:
+            filter_expression = Tag("user_id") == message.user_id
+        case _:
+            error_message = f"Unhandled scope: {scope!r}"
+            raise ValueError(error_message)
+    return filter_expression
 
 
 async def update_message_tokens(
@@ -19,7 +51,7 @@ async def update_message_tokens(
 
     Parameters
     ----------
-    redis : Redis
+    redis : redis.Redis
         The Redis connection instance.
     guild_id : int
         The ID of the guild.
@@ -48,15 +80,18 @@ async def update_message_tokens(
 async def save_message(
     redis: Redis,
     message: models.VectorizedMessage,
+    sentiment: models.SentimentResult,
 ) -> str:
     """Save a message on Redis.
 
     Parameters
     ----------
-    redis : Redis
+    redis : redis.Redis
         The Redis connection instance.
-    message : models.VectorizedMessage
+    message : courageous_comets.models.VectorizedMessage
         The message to save
+    sentiment: courageous_comets.models.SentimentResult
+        The sentiment analayis result of the message
 
     Returns
     -------
@@ -67,7 +102,7 @@ async def save_message(
     index.set_client(redis)
     return (
         await index.load(
-            [message.model_dump()],
+            [{**message.model_dump(), **sentiment.model_dump(by_alias=True)}],
             keys=[
                 key_schema.guild_messages(
                     guild_id=message.guild_id,
@@ -78,11 +113,11 @@ async def save_message(
     )[0]
 
 
-async def get_similar_messages(
+async def get_messages_by_semantics_similarity(
     redis: Redis,
     message: models.Message,
     embedding: bytes,
-    limit: int = 10,
+    limit: int = settings.QUERY_LIMIT,
     scope: StatisticScopeEnum = StatisticScopeEnum.GUILD,
 ) -> list[models.Message]:
     """
@@ -90,36 +125,26 @@ async def get_similar_messages(
 
     Parameters
     ----------
-    redis : Redis
+    redis : redis.Redis
         The Redis connection instance.
-    message : models.Message
+    message : courageous_comets.models.Message
         The comparison message.
     embedding: bytes
         The vector embedding of the message.
-    limit   :
-        The number of similar messages to fetch.
-    scope   : enums.StatisticScopeEnum
-        The scope to limit the search.
+    limit : int
+        The number of similar messages to fetch (default: settings.PAGE_SIZE).
+    scope : courageous_comets.enums.StatisticScopeEnum
+        The scope to limit the search (default: enums.StatisticScopeEnum.GUILD).
 
     Returns
     -------
-    list[models.Message]
-        The messages that are similar semantically.
+    list[courageous_comets.models.Message]
+        The messages that are semantically similar
     """
     index = AsyncSearchIndex.from_dict(schema.MESSAGE_SCHEMA)
     index.set_client(redis)
     # Determine the scope to filter the search
-    match scope:
-        case StatisticScopeEnum.GUILD:
-            filter_expression = Tag("guild_id") == message.guild_id
-        case StatisticScopeEnum.CHANNEL:
-            filter_expression = Tag("channel_id") == message.channel_id
-        case StatisticScopeEnum.USER:
-            filter_expression = Tag("user_id") == message.user_id
-        case _:
-            error_message = f"Unhandled scope: {scope!r}"
-            raise ValueError(error_message)
-
+    search_scope = get_search_scope(scope, message)
     query = VectorQuery(
         vector=embedding,
         vector_field_name="embedding",
@@ -130,6 +155,51 @@ async def get_similar_messages(
             "guild_id",
             "timestamp",
         ],
+        filter_expression=search_scope,
+        num_results=limit,
+    )
+    results = await index.query(query)
+    return [models.Message.model_validate(result) for result in results]
+
+
+async def get_messages_by_sentiment_similarity(  # noqa: PLR0913
+    redis: Redis,
+    message: models.Message,
+    sentiment: models.SentimentResult,
+    radius: float,
+    limit: int = settings.QUERY_LIMIT,
+    scope: StatisticScopeEnum = StatisticScopeEnum.GUILD,
+) -> list[models.Message]:
+    """
+    Get the messages with similar sentiment analysis.
+
+    Parameters
+    ----------
+    redis : redis.Redis
+        The Redis connection instance.
+    sentiment : courageous_comets.models.SentimentResult
+        The sentiment analayis result of a message.
+    radius: float
+        The distance threshold of the search.
+    limit : int
+        The number of similar messages to fetch (default: settings.PAGE_SIZE).
+    scope : courageous_comets.enums.StatisticScopeEnum
+        The scope to limit the search (default: enums.StatisticScopeEnum.GUILD).
+
+    Returns
+    -------
+    list[courageous_comets.models.Message]
+        The messages that are sentimentally similar.
+    """
+    index = AsyncSearchIndex.from_dict(schema.MESSAGE_SCHEMA)
+    index.set_client(redis)
+    # Determine the scope to filter the search
+    search_scope = get_search_scope(scope, message)
+    low = Num("sentiment_compound") >= sentiment.compound  # pyright: ignore
+    high = Num("sentiment_compound") <= sentiment.compound + radius  # pyright: ignore
+    filter_expression = search_scope & low & high
+    query = FilterQuery(
+        return_fields=["message_id", "user_id", "channel_id", "guild_id", "timestamp"],
         filter_expression=filter_expression,
         num_results=limit,
     )

--- a/courageous_comets/redis/schema.py
+++ b/courageous_comets/redis/schema.py
@@ -3,15 +3,18 @@ from courageous_comets import settings
 MESSAGE_SCHEMA = {
     "index": {
         "name": "message_idx",
-        "prefix": settings.REDIS_KEYS_PREFIX,
+        "prefix": f"{settings.REDIS_KEYS_PREFIX}:messages",
     },
     "fields": [
-        {"name": "content", "type": "text"},
         {"name": "user_id", "type": "tag"},
         {"name": "message_id", "type": "tag"},
         {"name": "channel_id", "type": "tag"},
         {"name": "guild_id", "type": "tag"},
         {"name": "timestamp", "type": "numeric", "attrs": {"sortable": True}},
+        {"name": "sentiment_neg", "type": "numeric", "attrs": {"sortable": True}},
+        {"name": "sentiment_neu", "type": "numeric", "attrs": {"sortable": True}},
+        {"name": "sentiment_pos", "type": "numeric", "attrs": {"sortable": True}},
+        {"name": "sentiment_compound", "type": "numeric", "attrs": {"sortable": True}},
         {
             "name": "embedding",
             "type": "vector",

--- a/courageous_comets/sentiment.py
+++ b/courageous_comets/sentiment.py
@@ -1,18 +1,15 @@
 import logging
 
-from discord import Message
 from nltk.sentiment import SentimentIntensityAnalyzer
-from redis.asyncio import Redis
 
 from courageous_comets.models import SentimentResult
-from courageous_comets.redis.keys import key_schema
 
 MAX_MESSAGE_LENGTH = 256
 
 logger = logging.getLogger(__name__)
 
 
-def calculate_sentiment(content: str, key: str) -> SentimentResult:
+def calculate_sentiment(content: str) -> SentimentResult:
     """
     Calculate the sentiment of a message.
 
@@ -25,8 +22,6 @@ def calculate_sentiment(content: str, key: str) -> SentimentResult:
     ----------
     content : str
         The message content to analyze.
-    key : str
-        The Redis key for the message. Used for logging.
 
     Returns
     -------
@@ -36,87 +31,9 @@ def calculate_sentiment(content: str, key: str) -> SentimentResult:
     truncated = content[:MAX_MESSAGE_LENGTH]
 
     if truncated != content:
-        logger.warning("Truncated message %s to %s characters", key, MAX_MESSAGE_LENGTH)
+        logger.warning("Truncated message to %s characters", MAX_MESSAGE_LENGTH)
 
     sia = SentimentIntensityAnalyzer()
     result = sia.polarity_scores(truncated)
 
     return SentimentResult.model_validate(result)
-
-
-async def store_sentiment(message: Message, redis: Redis) -> None:
-    """
-    Calculate the sentiment of a message and store the result in Redis.
-
-    A message must have a guild, channel, author and message ID. If any of these are missing,
-    the message will be ignored.
-
-    Empty messages will also be ignored.
-
-    Parameters
-    ----------
-    message : discord.Message
-        The message to process.
-    redis : redis.asyncio.Redis
-        The Redis connection instance.
-    """
-    # Ignore empty messages
-    if not message.content:
-        logger.warning("Ignoring empty message %s", message.id)
-        return
-
-    # Extract the IDs from the message
-    guild_id = message.guild.id if message.guild else 0
-    channel_id = message.channel.id if message.channel else 0
-    user_id = message.author.id if message.author else 0
-    message_id = message.id if message.id else 0
-
-    # Ignore messages without all required IDs
-    if not all((guild_id, channel_id, user_id, message_id)):
-        logger.warning("Ignoring message %s with missing IDs", message.id)
-        return
-
-    # Construct the Redis key
-    key = key_schema.sentiment_tokens(
-        guild_id=guild_id,
-        channel_id=channel_id,
-        user_id=user_id,
-        message_id=message_id,
-    )
-
-    # Calculate the sentiment
-    sentiment = calculate_sentiment(message.content, key)
-
-    # Store the sentiment in Redis
-    await redis.hset(
-        key,
-        mapping=sentiment.model_dump(mode="json"),
-    )  # pyright: ignore[reportGeneralTypeIssues]
-
-    logger.info("Stored sentiment for message %s", key)
-
-
-async def get_sentiment(key: str, redis: Redis) -> SentimentResult:
-    """
-    Retrieve the sentiment of a message from Redis.
-
-    Parameters
-    ----------
-    key : str
-        The Redis key to retrieve the sentiment from.
-    redis : redis.asyncio.Redis
-        The Redis connection instance.
-
-    Returns
-    -------
-    courageous_comets.models.SentimentResult
-        The sentiment of the message.
-    """
-    neg, neu, pos, compound = await redis.hmget(key, "neg", "neu", "pos", "compound")  # type: ignore
-
-    return SentimentResult(
-        neg=float(neg or 0),
-        neu=float(neu or 0),
-        pos=float(pos or 0),
-        compound=float(compound or 0),
-    )

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -160,6 +160,8 @@ try:
     REDIS_PORT = read_redis_port()
     REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
     REDIS_KEYS_PREFIX = os.getenv("REDIS_KEYS_PREFIX", "courageous_comets")
+    # Maximum number of items to return from a query
+    QUERY_LIMIT = read_int("QUERY_LIMIT", 10)
     # Huggingface environment variable for caching downloaded models.
     # https://huggingface.co/docs/huggingface_hub/v0.24.0/package_reference/environment_variables#hf_home
     HF_HOME = os.getenv(

--- a/tests/courageous_comets/test__sentiment.py
+++ b/tests/courageous_comets/test__sentiment.py
@@ -1,17 +1,12 @@
-from unittest.mock import Mock
-
 import pytest
-from pytest_mock import MockerFixture, MockType
+from pytest_mock import MockerFixture
 from redis.asyncio import Redis
 
 from courageous_comets.models import SentimentResult
-from courageous_comets.redis.keys import key_schema
 from courageous_comets.sentiment import (
     MAX_MESSAGE_LENGTH,
     calculate_sentiment,
-    get_sentiment,
     logger,
-    store_sentiment,
 )
 
 
@@ -40,7 +35,7 @@ def test__calculate_sentiment_analyzes_sentiment_of_given_text(
         pos=mocker.ANY,
         compound=mocker.ANY,
     )
-    result = calculate_sentiment("I love this product!", "test")
+    result = calculate_sentiment("I love this product!")
     assert result == expected
 
 
@@ -65,134 +60,5 @@ def test__calculate_sentiment_truncates_long_messages(
     - The function truncates messages longer than 256 characters.
     """
     logger_warning = mocker.spy(logger, "warning")
-    calculate_sentiment(message, "test")
+    calculate_sentiment(message)
     assert logger_warning.called == expected
-
-
-async def test__store_sentiment_calculates_and_stores_sentiment(
-    *,
-    mocker: MockerFixture,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function calculates and stores the sentiment of a message.
-
-    Asserts
-    -------
-    - The sentiment is calculated for the message content.
-    - The sentiment is stored in the database.
-    """
-    message = mocker.Mock(
-        content="I love this product!",
-        guild=Mock(id=1),
-        channel=Mock(id=1),
-        author=Mock(id=1),
-        id=1,
-    )
-
-    await store_sentiment(message, redis)
-
-    redis.hset.assert_awaited_with(
-        key_schema.sentiment_tokens(1, 1, 1, 1),
-        mapping={
-            "neg": mocker.ANY,
-            "neu": mocker.ANY,
-            "pos": mocker.ANY,
-            "compound": mocker.ANY,
-        },
-    )
-
-
-async def test__store_sentiment_ignores_empty_messages(
-    *,
-    mocker: MockerFixture,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function ignores empty messages.
-
-    Asserts
-    -------
-    - The database is not updated when the message is empty.
-    """
-    message = mocker.Mock(content="")
-    await store_sentiment(message, redis)
-    redis.hset.assert_not_awaited()
-
-
-@pytest.mark.parametrize(
-    "message",
-    [
-        Mock(content="test", guild=None, channel=None, author=None, id=1),
-        Mock(content="test", guild=Mock(id=1), channel=None, author=None, id=1),
-        Mock(content="test", guild=Mock(id=1), channel=Mock(id=1), author=None, id=1),
-    ],
-)
-async def test__store_sentiment_ignores_messages_without_ids(
-    *,
-    redis: MockType,
-    message: MockType,
-) -> None:
-    """
-    Test whether the store sentiment function ignores messages without IDs.
-
-    Asserts
-    -------
-    - The database is not updated when the message is missing IDs.
-    """
-    await store_sentiment(message, redis)
-    redis.hset.assert_not_awaited()
-
-
-async def test__get_sentiment_retrieves_sentiment_from_redis(
-    *,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the get sentiment function retrieves the sentiment of a message from Redis.
-
-    Asserts
-    -------
-    - The sentiment is retrieved from the database.
-    """
-    key = key_schema.sentiment_tokens(1, 1, 1, 1)
-    redis.hmget.return_value = ["1.0", "1.0", "1.0", "1.0"]
-
-    expected = SentimentResult(
-        neg=1.0,
-        neu=1.0,
-        pos=1.0,
-        compound=1.0,
-    )
-
-    result = await get_sentiment(key, redis)
-
-    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
-    assert result == expected
-
-
-async def test__get_sentiment_handles_missing_sentiment(
-    *,
-    redis: MockType,
-) -> None:
-    """
-    Test whether the get sentiment function handles missing sentiment in Redis.
-
-    Asserts
-    -------
-    - The function returns default sentiment values when the sentiment is missing.
-    """
-    key = key_schema.sentiment_tokens(1, 1, 1, 1)
-    redis.hmget.return_value = [None, None, None, None]
-
-    expected = SentimentResult(
-        neg=0.0,
-        neu=0.0,
-        pos=0.0,
-        compound=0.0,
-    )
-
-    result = await get_sentiment(key, redis)
-
-    redis.hmget.assert_awaited_with(key, "neg", "neu", "pos", "compound")
-    assert expected == result

--- a/tests/integrations/test__redis.py
+++ b/tests/integrations/test__redis.py
@@ -6,7 +6,12 @@ from redis.asyncio import Redis
 
 from courageous_comets import models
 from courageous_comets.redis.keys import key_schema
-from courageous_comets.redis.messages import get_similar_messages, save_message
+from courageous_comets.redis.messages import (
+    get_messages_by_semantics_similarity,
+    get_messages_by_sentiment_similarity,
+    save_message,
+)
+from courageous_comets.sentiment import calculate_sentiment
 from courageous_comets.vectorizer import Vectorizer
 
 
@@ -16,7 +21,7 @@ def message() -> models.Message:
 
     Returns
     -------
-    models.Message
+    courageous_comets.models.Message
         A Redis model of a Discord message
     """
     return models.Message(
@@ -28,54 +33,153 @@ def message() -> models.Message:
     )
 
 
+@pytest.fixture(scope="session")
+def content() -> str:
+    """Fixture that sets up the content of message.
+
+    Returns
+    -------
+    str
+        The message content.
+    """
+    return "The quick brown fox jumps over the lazy dog."
+
+
 @pytest_asyncio.fixture(scope="session")
 async def vectorized_message(
     message: models.Message,
+    content: str,
     vectorizer: Vectorizer,
 ) -> models.VectorizedMessage:
     """Fixture that creates an embedding vector of contents of message.
 
+    Parameters
+    ----------
+    message: courageous_comets.models.Message
+        The (base) model of the Discord message.
+    content:
+        The contents of the message.
+    vectorizer: courageous_comets.vectorizer.Vectorizer
+        The model that creates the embedding vector of content
+
     Returns
     -------
-    models.VectorizedMessage
-        A message with embedding vector
+    courageous_comets.models.VectorizedMessage
+        A message with embedding vector of contents.
     """
-    content = "The quick brown fox jumps over the lazy dog."
     embedding = await vectorizer.aencode(content)
     return models.VectorizedMessage(**message.model_dump(), embedding=embedding)
+
+
+@pytest.fixture(scope="session")
+def sentiment(content: str) -> models.SentimentResult:
+    """Fixture that calculates the sentiment analysis of content.
+
+    Parameters
+    ----------
+    content:
+        The text to run the sentiment analysis on.
+
+    Returns
+    -------
+    models.SentimentResult
+        The result of the sentiment analysis.
+    """
+    return calculate_sentiment(content)
 
 
 async def test__save_message(
     redis: Redis,
     vectorized_message: models.VectorizedMessage,
+    sentiment: models.SentimentResult,
 ) -> None:
     """
     Tests whether the save_mesage function stores the message on Redis.
+
+    Parameters
+    ----------
+    redis: redis.Redis
+        The Redis connection instance.
+    vectorized_message: courageous_comets.models.VectorizedMessage
+        The Discord message with an embedding vector of its content.
+    sentiment : courageous_comets.models.SentimentResult
+        The sentiment analayis result of a message.
 
     Asserts
     -------
     - The returned key is the same as the one constructed by the key_schema
     """
-    key = await save_message(redis, vectorized_message)
+    key = await save_message(redis, vectorized_message, sentiment)
     assert key == key_schema.guild_messages(
         guild_id=vectorized_message.guild_id,
         message_id=vectorized_message.message_id,
     )
 
 
-async def test__get_similar_message(
+async def test__get_messages_by_semantics_similarity(
     redis: Redis,
     message: models.Message,
     vectorized_message: models.VectorizedMessage,
+    sentiment: models.SentimentResult,
 ) -> None:
     """
     Tests that the same message is returned by the get_similar_messages function.
+
+    Parameters
+    ----------
+    redis: redis.Redis
+        The Redis connection instance.
+    message: courageous_comets.models.Message
+        The (base) model of the Discord message.
+    vectorized_message: courageous_comets.models.VectorizedMessage
+        The Discord message with an embedding vector of its content.
+    sentiment : courageous_comets.models.SentimentResult
+        The sentiment analayis result of a message.
 
     Asserts
     -------
     - The returned message is the same message whose embedding vector was used
     """
-    await save_message(redis, vectorized_message)
-    messages = await get_similar_messages(redis, message, vectorized_message.embedding)
+    await save_message(redis, vectorized_message, sentiment)
+    messages = await get_messages_by_semantics_similarity(
+        redis,
+        message,
+        vectorized_message.embedding,
+    )
+    assert len(messages) == 1
+    assert messages[0].model_dump() == message.model_dump()
+
+
+async def test__get_messages_by_sentiment_similarity(
+    redis: Redis,
+    message: models.Message,
+    vectorized_message: models.VectorizedMessage,
+    sentiment: models.SentimentResult,
+) -> None:
+    """
+    Tests that the same message is returned by the get_messages_by_sentiment_similarity function.
+
+    Parameters
+    ----------
+    redis: redis.Redis
+        The Redis connection instance.
+    message: courageous_comets.models.Message
+        The (base) model of the Discord message.
+    vectorized_message: courageous_comets.models.VectorizedMessage
+        The Discord message with an embedding vector of its content.
+    sentiment : courageous_comets.models.SentimentResult
+        The sentiment analayis result of a message.
+
+    Asserts
+    -------
+    - The returned message is the same message whose sentiment analysis result was used
+    """
+    await save_message(redis, vectorized_message, sentiment)
+    messages = await get_messages_by_sentiment_similarity(
+        redis,
+        message,
+        sentiment,
+        radius=0.1,
+    )
     assert len(messages) == 1
     assert messages[0].model_dump() == message.model_dump()


### PR DESCRIPTION
# Changes

- store sentiment result along with message vector
- create indexes with narrow prefix
- expand message index to include sentiment results
- add `serialization_alias` to `SentimentResult` to conform with name on Redis hash.
- monkey-patch schema prefix in conftest
- add function for sentiment similarity search
- give functions for searching messages more descriptive names
- remove redis-related code from `sentiment.py` and `test__sentiment.py`
- add setting for configuring how many items per query