### PR TITLE
feat: add development mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "containerEnv": {
     "BOT_CONFIG_PATH": "${containerWorkspaceFolder}/application.yaml",
+    "ENVIRONMENT": "development",
     "HF_HOME": "${containerWorkspaceFolder}/hf_data",
     "NLTK_DATA": "${containerWorkspaceFolder}/nltk_data",
     "POETRY_VIRTUALENVS_CREATE": "false",

--- a/application.yaml
+++ b/application.yaml
@@ -1,6 +1,7 @@
 cogs:
   - courageous_comets.cogs.messages
   - courageous_comets.cogs.ping
+dev-cogs:
   - jishaku
 nltk:
   - punkt

--- a/courageous_comets/client.py
+++ b/courageous_comets/client.py
@@ -93,6 +93,10 @@ class CourageousCometsBot(commands.Bot):
         cogs = CONFIG.get("cogs", [])
         await self.load_cogs(cogs)
 
+        if settings.IS_DEV:
+            dev_cogs = CONFIG.get("dev-cogs", [])
+            await self.load_cogs(dev_cogs)
+
         logger.info("Initialization complete 🚀")
 
 

--- a/courageous_comets/settings.py
+++ b/courageous_comets/settings.py
@@ -148,6 +148,12 @@ LOG_LEVEL = logging.getLevelNamesMapping().get(
 
 setup_logging()
 
+# Determine whether the application is running in a development environment
+IS_DEV = os.getenv("ENVIRONMENT", "production") == "development"
+
+if IS_DEV:
+    logging.warning("🚨 Application is running in development mode! 🚨")
+
 # Load configuration values from the environment
 try:
     DISCORD_TOKEN = read_discord_token()

--- a/docs/admin-guide/configuration.md
+++ b/docs/admin-guide/configuration.md
@@ -6,6 +6,7 @@ The following environment variables are available to configure the application:
 | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------- | ------------------ |
 | [`DISCORD_TOKEN`](#discord_token)                                                 | The Discord bot token.                                                   | Yes      | -                  |
 | [`BOT_CONFIG_PATH`](#bot_config_path)                                             | The path to the bot's configuration file.                                | No       | `application.yaml` |
+| [`ENVIRONMENT`](#environment)                                                     | The environment in which the application is running.                     | No       | `production`       |
 | [`HF_DOWNLOAD_CONCURRENCY`](#hf_download_concurrency)                             | The maximum number of concurrent downloads when installing transformers. | No       | `3`                |
 | [`HF_HOME`](#hf_home)                                                             | The directory containing Huggingface Transformers data files.            | No       | `hf_data`          |
 | [`LOG_LEVEL`](#log_level)                                                         | The minimum log level.                                                   | No       | `INFO`             |
@@ -44,6 +45,10 @@ This specifies the location of the bot's configuration file, which is a YAML fil
 cogs:
   - <PACKAGE_NAME>
   - <PACKAGE_NAME>
+# List of cogs to load in development mode only, identified by their package name.
+dev-cogs:
+  - <PACKAGE_NAME>
+  - <PACKAGE_NAME>
 # List of NLTK datasets to download on startup.
 nltk:
   - <DATASET_NAME>
@@ -56,6 +61,11 @@ transformers:
 
 By default, the application searches for a file named `application.yaml` in the directory from which it is launched.
 In the Docker image, this file is located at `/app/application.yaml`.
+
+### `ENVIRONMENT`
+
+The environment in which the application is running. Set this to `development` to enable development features
+such as loading development cogs. By default, this is set to `production`.
 
 ### `HF_DOWNLOAD_CONCURRENCY`
 


### PR DESCRIPTION
Add the `IS_DEV` setting that determines whether or not the application is running in development mode. Development mode is enabled by setting the following environment variable:

```dotenv
ENVIRONMENT=development
```

## Changes
- Add `IS_DEV` setting to `settings.py`. It is configured via the environment variable `ENVIRONMENT`. 
- Evaluates to `false` unless the environment is `development`.
- Set `ENVIRONMENT=development` in the devcontainer.
- Log a warning if the app is running in development mode.
- Extend `application.yaml` with a `dev-cogs` section which are only loaded in development mode.
- Move `jishaku` to `dev-cogs`.
- Update the configuration guide.